### PR TITLE
feat: single file review mode

### DIFF
--- a/src/main/xml-serializer.test.ts
+++ b/src/main/xml-serializer.test.ts
@@ -85,6 +85,20 @@ describe('serializeReview', () => {
       expect(xml).not.toContain('repository');
     });
 
+    it('serializes file mode review with source-path attribute', async () => {
+      const reviewState: ReviewState = {
+        timestamp: '2024-01-15T10:30:00Z',
+        source: { type: 'file', sourcePath: '/home/user/document.md' },
+        files: [],
+      };
+
+      const xml = await serializeReview(reviewState, TEST_OUTPUT_PATH);
+
+      expect(xml).toContain('source-path="/home/user/document.md"');
+      expect(xml).not.toContain('git-diff-args');
+      expect(xml).not.toContain('repository');
+    });
+
     it('serializes welcome mode review with no source attributes', async () => {
       const reviewState: ReviewState = {
         timestamp: '2024-01-15T10:30:00Z',

--- a/src/main/xml-serializer.ts
+++ b/src/main/xml-serializer.ts
@@ -358,7 +358,7 @@ function buildSourceAttributes(state: ReviewState): string {
   if (source.type === 'git') {
     return ` git-diff-args="${escapeXml(source.gitDiffArgs)}" repository="${escapeXml(source.repository)}"`;
   }
-  if (source.type === 'directory') {
+  if (source.type === 'directory' || source.type === 'file') {
     return ` source-path="${escapeXml(source.sourcePath)}"`;
   }
   // welcome mode: no source attributes

--- a/src/renderer/components/DiffViewer/DiffViewer.tsx
+++ b/src/renderer/components/DiffViewer/DiffViewer.tsx
@@ -65,6 +65,29 @@ export default function DiffViewer() {
       return null;
     }
 
+    // File mode: error message (shouldn't normally happen)
+    if (diffSource.type === 'file') {
+      return (
+        <div
+          className='flex-1 flex items-center justify-center p-8'
+          data-testid='empty-diff-help'
+        >
+          <div className='max-w-lg space-y-6'>
+            <h2 className='text-lg font-semibold text-foreground text-center'>
+              Could not read file
+            </h2>
+            <p className='text-sm text-muted-foreground text-center'>
+              The file{' '}
+              <code className='px-1 py-0.5 rounded bg-muted text-xs font-mono'>
+                {diffSource.sourcePath}
+              </code>{' '}
+              could not be read or is empty.
+            </p>
+          </div>
+        </div>
+      );
+    }
+
     // Directory mode: simple message
     if (diffSource.type === 'directory') {
       return (

--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -19,6 +19,7 @@ import {
   MoveHorizontal,
   Terminal,
   FolderOpen,
+  FileText,
   CheckCircle2,
 } from 'lucide-react';
 
@@ -174,7 +175,9 @@ export default function Toolbar() {
         data-testid='diff-stats'
       >
         <span className='inline-flex items-center gap-1 font-mono'>
-          {diffSource.type === 'directory' ? (
+          {diffSource.type === 'file' ? (
+            <FileText className='h-3 w-3' />
+          ) : diffSource.type === 'directory' ? (
             <FolderOpen className='h-3 w-3' />
           ) : (
             <Terminal className='h-3 w-3' />
@@ -183,7 +186,9 @@ export default function Toolbar() {
             ? `git diff${diffSource.gitDiffArgs ? ` ${diffSource.gitDiffArgs}` : ''}`
             : diffSource.type === 'directory'
               ? `Directory: ${diffSource.sourcePath}`
-              : ''}
+              : diffSource.type === 'file'
+                ? `File: ${diffSource.sourcePath.split('/').pop()}`
+                : ''}
         </span>
         <Separator orientation='vertical' className='h-3.5' />
         <span>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,6 +38,7 @@ export interface DiffFile {
 export type DiffSource =
   | { type: 'git'; gitDiffArgs: string; repository: string }
   | { type: 'directory'; sourcePath: string }
+  | { type: 'file'; sourcePath: string }
   | { type: 'welcome' };
 
 // ===== Review State Types =====


### PR DESCRIPTION
## Summary

- Add single file review mode: pass a file path as CLI argument to review an individual file with all content shown as added
- Handle multiple source contexts: git-tracked files use existing diff behavior, untracked or non-repo files use the new file mode
- Extend `scanFile()` in directory-scanner, with updates to XML serializer, IPC handlers, and renderer to support the `file` source type

## Test plan

- [ ] Run `self-review path/to/file.ts` on a tracked file in a git repo — should show git diff
- [ ] Run `self-review path/to/untracked.ts` on an untracked file — should show full content as added
- [ ] Run `self-review path/to/file.ts` outside a git repo — should show full content as added
- [ ] Verify XML output includes correct `source="file"` attribute
- [ ] Run `npm run test:unit` — all 204 tests pass