### PR TITLE
feat: add logo and branding to welcome screen

### DIFF
--- a/src/renderer/components/WelcomeScreen.tsx
+++ b/src/renderer/components/WelcomeScreen.tsx
@@ -8,6 +8,47 @@ import {
   CardTitle,
 } from './ui/card';
 
+function Logo({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className={className}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#1e293b" />
+          <stop offset="100%" stopColor="#0f172a" />
+        </linearGradient>
+      </defs>
+      <rect width="512" height="512" rx="96" ry="96" fill="url(#bg)" />
+      <rect x="60" y="144" width="392" height="56" rx="12" fill="#dc2626" opacity="0.2" />
+      <rect x="78" y="168" width="20" height="6" rx="3" fill="#f87171" />
+      <rect x="120" y="164" width="140" height="20" rx="6" fill="#f87171" opacity="0.8" />
+      <rect x="276" y="164" width="80" height="20" rx="6" fill="#f87171" opacity="0.5" />
+      <rect x="120" y="228" width="100" height="16" rx="5" fill="#94a3b8" opacity="0.35" />
+      <rect x="236" y="228" width="60" height="16" rx="5" fill="#94a3b8" opacity="0.25" />
+      <rect x="60" y="268" width="392" height="56" rx="12" fill="#16a34a" opacity="0.2" />
+      <rect x="78" y="293" width="20" height="6" rx="3" fill="#4ade80" />
+      <rect x="85" y="286" width="6" height="20" rx="3" fill="#4ade80" />
+      <rect x="120" y="288" width="172" height="20" rx="6" fill="#4ade80" opacity="0.8" />
+      <rect x="308" y="288" width="64" height="20" rx="6" fill="#4ade80" opacity="0.5" />
+      <rect x="120" y="352" width="80" height="16" rx="5" fill="#94a3b8" opacity="0.35" />
+      <circle cx="400" cy="400" r="56" fill="#0f172a" opacity="0.6" />
+      <circle cx="400" cy="400" r="48" fill="#22c55e" />
+      <polyline
+        points="378,400 394,416 424,384"
+        fill="none"
+        stroke="#fff"
+        strokeWidth="9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export default function WelcomeScreen() {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -44,11 +85,15 @@ export default function WelcomeScreen() {
       className="flex items-center justify-center h-full bg-background"
     >
       <div className="w-full max-w-lg space-y-6 p-6">
-        <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">self-review</h1>
-          <p className="text-muted-foreground">
-            Review code locally with a GitHub-style PR interface
-          </p>
+        <div className="text-center space-y-4">
+          <Logo className="w-20 h-20 mx-auto" />
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold tracking-tight">Self Review</h1>
+            <p className="text-muted-foreground">
+              GitHub-style PR review UI for local git diffs. Designed for solo
+              developers reviewing AI-generated code.
+            </p>
+          </div>
         </div>
 
         <Card>


### PR DESCRIPTION
## Summary
- Add project logo (inlined SVG from `assets/icon.svg`) to welcome screen
- Rename title from "self-review" to human-readable "Self Review"
- Update description to include full project purpose

## Test plan
- [ ] Launch app without CLI args to see welcome screen
- [ ] Verify logo renders correctly
- [ ] Verify title reads "Self Review"
- [ ] Unit tests pass (204/204)