### PR TITLE
feat: auto-focus editor and reorder categories

### DIFF
--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -36,7 +36,7 @@ describe('config', () => {
       expect(config.fontSize).toBe(14);
       expect(config.outputFile).toBe('./review.xml');
       expect(config.categories).toHaveLength(5);
-      expect(config.categories[0].name).toBe('bug');
+      expect(config.categories[0].name).toBe('question');
       expect(config.wordWrap).toBe(true);
     });
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -16,6 +16,11 @@ const defaults: AppConfig = {
   ignore: [],
   categories: [
     {
+      name: 'question',
+      description: 'Clarification needed — not necessarily a problem',
+      color: '#805ad5',
+    },
+    {
       name: 'bug',
       description: 'Likely defect or incorrect behavior',
       color: '#e53e3e',
@@ -29,11 +34,6 @@ const defaults: AppConfig = {
       name: 'style',
       description: 'Code style, naming, or formatting issue',
       color: '#3182ce',
-    },
-    {
-      name: 'question',
-      description: 'Clarification needed — not necessarily a problem',
-      color: '#805ad5',
     },
     {
       name: 'nit',

--- a/src/renderer/components/Comments/CommentInput.tsx
+++ b/src/renderer/components/Comments/CommentInput.tsx
@@ -108,6 +108,7 @@ export default function CommentInput({
   const [proposedCode, setProposedCode] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const editorContainerRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const dragCounter = useRef(0);
 
@@ -158,6 +159,12 @@ export default function CommentInput({
     if (dragCounter.current === 0) {
       setIsDragging(false);
     }
+  }, []);
+
+  useEffect(() => {
+    // Auto-focus the editor textarea when the comment input mounts
+    const textarea = editorContainerRef.current?.querySelector<HTMLTextAreaElement>('.w-md-editor-text-input');
+    textarea?.focus();
   }, []);
 
   useEffect(() => {
@@ -235,7 +242,7 @@ export default function CommentInput({
           </div>
         </div>
       )}
-      <div className='p-1' data-color-mode={isDark ? 'dark' : 'light'}>
+      <div className='p-1' data-color-mode={isDark ? 'dark' : 'light'} ref={editorContainerRef}>
         <MDEditor
           value={body}
           onChange={(val) => setBody(val || '')}


### PR DESCRIPTION
## Summary
- Auto-focus the MDEditor textarea when a comment input opens, so users can start typing immediately after clicking `+`
- Reorder default categories to make `question` the first option instead of `bug`

## Test plan
- [x] Unit tests updated and passing (204/204)
- [ ] Open the app, click `+` on a diff line, verify the editor textarea receives focus
- [ ] Verify the category selector defaults to `question`