### PR TITLE
fix: scope scroll queries to diff viewer

### DIFF
--- a/src/renderer/context/DiffNavigationContext.tsx
+++ b/src/renderer/context/DiffNavigationContext.tsx
@@ -30,7 +30,8 @@ export function DiffNavigationProvider({ children }: { children: ReactNode }) {
   const [activeFilePath, setActiveFilePath] = useState<string | null>(null);
 
   const scrollToFile = useCallback((filePath: string) => {
-    const element = document.querySelector(`[data-file-path="${filePath}"]`);
+    const diffViewer = document.querySelector('[data-diff-viewer]');
+    const element = diffViewer?.querySelector(`[data-file-path="${filePath}"]`);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
@@ -64,9 +65,11 @@ export function DiffNavigationProvider({ children }: { children: ReactNode }) {
       }
     );
 
-    // Observe all file sections
+    // Observe all file sections (scoped to diff viewer to avoid FileTree buttons)
     const observeElements = () => {
-      const elements = document.querySelectorAll('[data-file-path]');
+      const diffViewer = document.querySelector('[data-diff-viewer]');
+      if (!diffViewer) return;
+      const elements = diffViewer.querySelectorAll('[data-file-path]');
       elements.forEach(el => observer.observe(el));
     };
 

--- a/src/renderer/hooks/useDiffNavigation.test.ts
+++ b/src/renderer/hooks/useDiffNavigation.test.ts
@@ -60,12 +60,20 @@ describe('useDiffNavigation', () => {
   });
 
   describe('scrollToFile', () => {
-    it('scrolls to element with matching data-file-path', () => {
+    let diffViewer: HTMLDivElement;
+
+    beforeEach(() => {
+      diffViewer = document.createElement('div');
+      diffViewer.setAttribute('data-diff-viewer', '');
+      document.body.appendChild(diffViewer);
+    });
+
+    it('scrolls to element with matching data-file-path inside diff viewer', () => {
       const mockElement = document.createElement('div');
       mockElement.setAttribute('data-file-path', 'test.ts');
       const scrollIntoViewMock = vi.fn();
       mockElement.scrollIntoView = scrollIntoViewMock;
-      document.body.appendChild(mockElement);
+      diffViewer.appendChild(mockElement);
 
       const { result } = renderHook(() => useDiffNavigation(), { wrapper });
 
@@ -90,6 +98,22 @@ describe('useDiffNavigation', () => {
       expect(result.current.activeFilePath).toBeNull();
     });
 
+    it('ignores elements outside diff viewer', () => {
+      const outsideElement = document.createElement('div');
+      outsideElement.setAttribute('data-file-path', 'test.ts');
+      const scrollMock = vi.fn();
+      outsideElement.scrollIntoView = scrollMock;
+      document.body.appendChild(outsideElement);
+
+      const { result } = renderHook(() => useDiffNavigation(), { wrapper });
+
+      act(() => {
+        result.current.scrollToFile('test.ts');
+      });
+
+      expect(scrollMock).not.toHaveBeenCalled();
+    });
+
     it('handles multiple files and scrolls to correct one', () => {
       const element1 = document.createElement('div');
       element1.setAttribute('data-file-path', 'file1.ts');
@@ -101,8 +125,8 @@ describe('useDiffNavigation', () => {
       const scroll2 = vi.fn();
       element2.scrollIntoView = scroll2;
 
-      document.body.appendChild(element1);
-      document.body.appendChild(element2);
+      diffViewer.appendChild(element1);
+      diffViewer.appendChild(element2);
 
       const { result } = renderHook(() => useDiffNavigation(), { wrapper });
 


### PR DESCRIPTION
## Summary
- Fix file tree click not scrolling to the corresponding file in the diff viewer
- `scrollToFile` and `IntersectionObserver` used unscoped `querySelector('[data-file-path]')` which matched FileTree buttons (first in DOM order) instead of FileSection divs
- Scope both queries to the `[data-diff-viewer]` container

## Test plan
- [x] Unit tests updated and passing (205/205)
- [ ] Click a file in the file tree and verify the diff viewer scrolls to that file
- [ ] Verify active file highlighting in the tree updates correctly when scrolling the diff viewer