### PR TITLE
fix: tooltip renders above sticky file headers

### DIFF
--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -37,6 +37,7 @@ const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
         align={align}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
+        className="z-50"
       >
         <TooltipPrimitive.Popup
           ref={ref}


### PR DESCRIPTION
## Summary
- Add `z-50` to `TooltipPrimitive.Positioner` so tooltip popups render above sticky file section headers (`z-10`)
- Fixes tooltips for "Viewed" toggle and "Add file comment" buttons being clipped under subsequent file headers

## Test plan
- [x] All 204 unit tests passing
- [ ] Open a review with multiple files, hover over Viewed/Comment buttons on a file that has another file below it — tooltip should render on top