### PR TITLE
feat(config): add default 'task' category

### DIFF
--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -35,7 +35,7 @@ describe('config', () => {
       expect(config.diffView).toBe('split');
       expect(config.fontSize).toBe(14);
       expect(config.outputFile).toBe('./review.xml');
-      expect(config.categories).toHaveLength(5);
+      expect(config.categories).toHaveLength(6);
       expect(config.categories[0].name).toBe('question');
       expect(config.wordWrap).toBe(true);
     });
@@ -242,7 +242,7 @@ categories:
 
       const config = loadConfig();
 
-      // Should have only 1 category, not 6 (1 custom + 5 defaults)
+      // Should have only 1 category, not 7 (1 custom + 6 defaults)
       expect(config.categories).toHaveLength(1);
       expect(config.categories[0].name).toBe('only-this');
     });

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -36,6 +36,11 @@ const defaults: AppConfig = {
       color: '#3182ce',
     },
     {
+      name: 'task',
+      description: 'Action item or follow-up task',
+      color: '#38a169',
+    },
+    {
       name: 'nit',
       description: 'Minor nitpick, low priority',
       color: '#718096',

--- a/src/renderer/context/ConfigContext.tsx
+++ b/src/renderer/context/ConfigContext.tsx
@@ -38,6 +38,11 @@ const defaultConfig: AppConfig = {
       color: '#805ad5',
     },
     {
+      name: 'task',
+      description: 'Action item or follow-up task',
+      color: '#38a169',
+    },
+    {
       name: 'nit',
       description: 'Minor nitpick, low priority',
       color: '#718096',


### PR DESCRIPTION
## Summary

Adds a new default `task` category (green `#38a169`) to the built-in category set, for marking action items and follow-up tasks during reviews.

- Added to main process defaults (`src/main/config.ts`)
- Added to renderer fallback defaults (`src/renderer/context/ConfigContext.tsx`)
- Updated test expectations to reflect 6 default categories

Closes #20

## Test plan

- [x] All 212 unit tests pass (164 main + 48 renderer)
- [ ] Verify `task` category appears in the category selector UI
- [ ] Verify the green color renders correctly in both light and dark themes