### PR TITLE
fix: toml bracket rendering broken

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,11 @@ body {
   background: hsl(var(--border) / 0.5);
 }
 
+/* Prevent Tailwind .table utility from overriding Prism token spans */
+.token.table {
+  display: inline;
+}
+
 /* MDEditor overrides for CommentInput */
 .md-editor-comment.w-md-editor {
   border: none !important;


### PR DESCRIPTION
## Summary

Fixes TOML section headers like `[build-system]` and `[project]` rendering with brackets on separate lines.

**Root cause:** Prism.js tokenizes TOML table headers as `<span class="token table class-name">`. Tailwind CSS's `.table` utility applies `display: table` to that span, breaking inline flow and pushing `[` and `]` onto separate visual lines.

**Fix:** Override with `.token.table { display: inline; }` in the global stylesheet.

Closes #19

## Test plan

- [x] All 212 unit tests pass (164 main + 48 renderer)
- [ ] Open a `.toml` file with section headers (e.g. `[build-system]`) and verify they render on a single line
- [ ] Verify other Prism-highlighted languages are unaffected