### PR TITLE
Add loading spinner on startup

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -34,16 +34,41 @@ function AppContent() {
     return <WelcomeScreen />;
   }
 
+  if (diffSource.type === 'loading') {
+    return (
+      <div className="flex items-center justify-center h-screen bg-background">
+        <svg
+          className="animate-spin h-8 w-8 text-muted-foreground"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      </div>
+    );
+  }
+
   return (
     <DiffNavigationProvider>
       <TooltipProvider>
         <KeyboardNavigationManager />
-        {diffSource.type !== 'loading' && (
-          <div className='flex flex-col h-screen bg-background text-foreground antialiased'>
-            <Toolbar />
-            <Layout />
-          </div>
-        )}
+        <div className='flex flex-col h-screen bg-background text-foreground antialiased'>
+          <Toolbar />
+          <Layout />
+        </div>
         <FindBar isOpen={isFindBarOpen} onClose={() => setIsFindBarOpen(false)} />
         <CloseConfirmDialog />
       </TooltipProvider>


### PR DESCRIPTION
## Summary
- Show a centered spinner animation instead of a blank page while diff data loads during app startup
- Uses Tailwind's `animate-spin` utility with theme-aware colors (`bg-background`, `text-muted-foreground`)
- No new dependencies added

## Test plan
- [x] All 216 unit tests pass (168 main + 48 renderer)
- [x] ESLint passes with no errors
- [x] Manual: launch app and verify spinner appears before diff content loads
- [x] Manual: verify spinner renders correctly in both light and dark themes