### PR TITLE
Fix Ctrl+F find bar focus loss and cycling

### DIFF
--- a/src/renderer/components/FindBar.tsx
+++ b/src/renderer/components/FindBar.tsx
@@ -98,10 +98,10 @@ export function FindBar({ isOpen, onClose }: FindBarProps) {
       if (result.finalUpdate) {
         setActiveMatch(result.activeMatchOrdinal);
         setTotalMatches(result.matches);
-        // Refocus input after Chromium's findInPage steals focus
-        requestAnimationFrame(() => {
-          inputRef.current?.focus();
-        });
+        // Don't refocus — Chromium's findInPage steals focus to highlight
+        // matches, and refocusing invalidates the find session, breaking
+        // Enter/button cycling. The global keydown handler catches Enter
+        // when input doesn't have focus.
       }
     });
 
@@ -167,9 +167,15 @@ export function FindBar({ isOpen, onClose }: FindBarProps) {
 
   if (!isOpen) return null;
 
-  const matchDisplay = query
-    ? totalMatches > 0
-      ? `${activeMatch} of ${totalMatches}`
+  // Chromium's findInPage searches the entire DOM including the find bar's
+  // own input, so the query text in the input always counts as one extra match.
+  // Subtract 1 from the total and cap the active ordinal accordingly.
+  const adjustedTotal = Math.max(0, totalMatches - 1);
+  const adjustedActive = Math.min(activeMatch, adjustedTotal);
+  const searched = query && lastSearchedQueryRef.current === query;
+  const matchDisplay = searched
+    ? adjustedTotal > 0
+      ? `${adjustedActive} of ${adjustedTotal}`
       : 'No results'
     : '';
 
@@ -194,7 +200,7 @@ export function FindBar({ isOpen, onClose }: FindBarProps) {
         size="icon"
         className="h-7 w-7"
         onClick={findPrevious}
-        disabled={!query || totalMatches === 0}
+        disabled={!query || adjustedTotal === 0}
         title="Previous match (Shift+Enter)"
       >
         <ChevronUp className="h-4 w-4" />
@@ -204,7 +210,7 @@ export function FindBar({ isOpen, onClose }: FindBarProps) {
         size="icon"
         className="h-7 w-7"
         onClick={findNext}
-        disabled={!query || totalMatches === 0}
+        disabled={!query || adjustedTotal === 0}
         title="Next match (Enter)"
       >
         <ChevronDown className="h-4 w-4" />

--- a/tests/features/14-find-in-page.feature
+++ b/tests/features/14-find-in-page.feature
@@ -24,24 +24,24 @@ Feature: Find in Page
     When I press "Ctrl+F"
     And I type "token" in the find bar
     And I press "Enter"
-    Then the match counter should show "1 of 5"
+    Then the match counter should show "1 of 4"
     And the first match should be highlighted
 
   Scenario: Cycling through matches with Enter
     When I press "Ctrl+F"
     And I type "token" in the find bar
     And I press "Enter"
-    Then the match counter should show "1 of 5"
+    Then the match counter should show "1 of 4"
     And I press "Enter"
-    Then the match counter should show "2 of 5"
+    Then the match counter should show "2 of 4"
     And I press "Enter"
-    Then the match counter should show "3 of 5"
+    Then the match counter should show "3 of 4"
 
   Scenario: Searching for multi-character queries
     When I press "Ctrl+F"
     And I type "authenticate" in the find bar
     And I press "Enter"
-    Then the match counter should show "1 of 2"
+    Then the match counter should show "1 of 1"
 
   Scenario: Closing find bar with Escape
     When I press "Ctrl+F"


### PR DESCRIPTION
## Summary

- Replace search-as-you-type with Enter-to-search in FindBar to prevent Chromium's `findInPage()` from stealing focus on every keystroke
- Remove `requestAnimationFrame` refocus from `onFindResult` that was invalidating Chromium's find session, breaking Enter/button match cycling
- Subtract 1 from displayed match count to exclude the false positive match inside the find bar's own input element
- Show empty counter while typing (before first Enter) instead of misleading "No results"

## Test plan

- [x] Type a multi-character query in Ctrl+F — input retains focus throughout typing
- [x] Press Enter — search highlights matches with correct count (excludes input match)
- [x] Press Enter repeatedly — counter cycles through matches
- [x] Click Next/Previous buttons — counter cycles correctly
- [x] Press Shift+Enter — cycles in reverse
- [x] Clear the input — highlights are removed
- [x] Press Escape — find bar closes
- [x] Vimium shortcuts (f, g, j, k) remain suppressed while find input is focused
- [x] Run e2e tests: `npm run test:e2e` on host machine

Closes #29