### PR TITLE
feat: add vimium hints to delete/finish

### DIFF
--- a/src/renderer/components/Comments/CommentDisplay.tsx
+++ b/src/renderer/components/Comments/CommentDisplay.tsx
@@ -217,6 +217,7 @@ export default function CommentDisplay({ comment, originalCode: originalCodeProp
               variant='ghost'
               size='sm'
               onClick={handleDelete}
+              data-hint-action='delete-comment'
               className='h-6 w-6 p-0 text-muted-foreground hover:text-destructive'
             >
               <Trash2 className='h-3 w-3' />

--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -299,6 +299,7 @@ export default function Toolbar() {
                 variant='default'
                 size='sm'
                 data-testid='finish-review-btn'
+                data-hint-action='finish-review'
                 onClick={() => window.electronAPI.saveAndQuit()}
                 className='gap-1.5 h-8 px-3'
                 disabled={!outputPathInfo.outputPathWritable}

--- a/src/renderer/hooks/useKeyboardNavigation.ts
+++ b/src/renderer/hooks/useKeyboardNavigation.ts
@@ -73,7 +73,7 @@ export function useKeyboardNavigation() {
 
         // Comment form buttons and file-level actions: just click them
         const hintAction = hint.element.getAttribute('data-hint-action');
-        if (testId === 'cancel-comment-btn' || testId === 'add-comment-btn' || testId?.startsWith('category-option-') || hintAction === 'toggle-viewed' || hintAction === 'add-file-comment') {
+        if (testId === 'cancel-comment-btn' || testId === 'add-comment-btn' || testId?.startsWith('category-option-') || hintAction === 'toggle-viewed' || hintAction === 'add-file-comment' || hintAction === 'delete-comment' || hintAction === 'finish-review') {
           hint.element.click();
           clearHintsRef.current();
           return;
@@ -130,7 +130,7 @@ export function useKeyboardNavigation() {
     let selector: string;
     if (newMode === 'hint-diff') {
       selector =
-        '[data-line-type="addition"][data-line-number][data-line-side], [data-line-type="deletion"][data-line-number][data-line-side], [data-testid="cancel-comment-btn"], [data-testid="add-comment-btn"], [data-testid^="category-option-"], [data-hint-action="toggle-viewed"], [data-hint-action="add-file-comment"]';
+        '[data-line-type="addition"][data-line-number][data-line-side], [data-line-type="deletion"][data-line-number][data-line-side], [data-testid="cancel-comment-btn"], [data-testid="add-comment-btn"], [data-testid^="category-option-"], [data-hint-action="toggle-viewed"], [data-hint-action="add-file-comment"], [data-hint-action="delete-comment"], [data-hint-action="finish-review"]';
     } else {
       selector =
         '.file-tree [data-file-path], [data-testid="file-tree"] [data-file-path], button[data-file-path]';


### PR DESCRIPTION
## Summary
- Add `data-hint-action` attributes to comment delete icons and the Finish Review button
- Include both new targets in the `f`-key hint overlay selector and click handler
- Enables keyboard-only activation of delete and finish review via Vimium-style hints

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 236 unit tests pass
- [ ] Press `f` with comments present — verify hint labels appear on delete icons
- [ ] Press `f` — verify a hint label appears on the Finish Review button
- [ ] Activate a delete hint — verify the comment is deleted
- [ ] Activate the finish review hint — verify save-and-quit triggers