### PR TITLE
feat: add npm publishing for workspace packages via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       actions: write
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     steps:
@@ -40,6 +41,7 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 
@@ -64,6 +66,16 @@ jobs:
             echo "No new release tag created"
             echo "tag=" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Publish workspace packages to npm
+        if: steps.tag.outputs.tag != ''
+        run: |
+          VERSION="${{ steps.tag.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          echo "Publishing workspace packages at version $VERSION"
+          for pkg in packages/core packages/react; do
+            (cd "$pkg" && npm pkg set "version=$VERSION" && npm run build && npm publish --provenance --access public)
+          done
 
       - name: Install Linux maker dependencies
         if: steps.tag.outputs.tag != ''

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@self-review/core",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Core library for self-review: diff parsing, git operations, XML serialization, and configuration",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/e0ipso/self-review.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@self-review/react",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "React components for self-review: embeddable code review UI with diff viewer and commenting",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/e0ipso/self-review.git",
+    "directory": "packages/react"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Bump @self-review/core and @self-review/react to v1.0.0
- Add publishConfig (access: public) and repository fields to both packages
- Add id-token: write permission and registry-url to release workflow
- Add publish step that builds and publishes workspace packages after
  semantic-release creates a new tag, using npm provenance via OIDC

https://claude.ai/code/session_0126V3UDge2XXLbQWZgqXTT8