### PR TITLE
fix: change default diff view from split to unified

### DIFF
--- a/src/renderer/context/ConfigContext.tsx
+++ b/src/renderer/context/ConfigContext.tsx
@@ -11,7 +11,7 @@ import darkThemeCss from 'prism-themes/themes/prism-one-dark.css?raw';
 
 const defaultConfig: AppConfig = {
   theme: 'system',
-  diffView: 'split',
+  diffView: 'unified',
   fontSize: 14,
   outputFormat: 'xml',
   outputFile: './review.xml',


### PR DESCRIPTION
## Summary
Updated the default diff view configuration from split view to unified view in the application settings.

## Changes
- Changed `diffView` default value from `'split'` to `'unified'` in `ConfigContext.tsx`

## Details
This change modifies the initial user experience by presenting diffs in unified format by default instead of the split (side-by-side) format. Users can still manually switch between diff view modes as needed through the application settings.