### PR TITLE
fix: npm OIDC publishing and version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 
@@ -70,11 +69,8 @@ jobs:
       - name: Publish workspace packages to npm
         if: steps.tag.outputs.tag != ''
         run: |
-          VERSION="${{ steps.tag.outputs.tag }}"
-          VERSION="${VERSION#v}"
-          echo "Publishing workspace packages at version $VERSION"
           for pkg in packages/core packages/react; do
-            (cd "$pkg" && npm pkg set "version=$VERSION" && npm run build && npm publish --provenance --access public)
+            (cd "$pkg" && npm run build && npm publish --provenance --access public)
           done
 
       - name: Install Linux maker dependencies

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,8 +4,10 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", { "npmPublish": false }],
+    ["@semantic-release/npm", { "npmPublish": false, "pkgRoot": "packages/core" }],
+    ["@semantic-release/npm", { "npmPublish": false, "pkgRoot": "packages/react" }],
     ["@semantic-release/git", {
-      "assets": ["package.json", "package-lock.json"],
+      "assets": ["package.json", "package-lock.json", "packages/core/package.json", "packages/react/package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]"
     }],
     "@semantic-release/github"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@self-review/core",
-  "version": "1.0.0",
+  "version": "1.26.1",
   "description": "Core library for self-review: diff parsing, git operations, XML serialization, and configuration",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@self-review/react",
-  "version": "1.0.0",
+  "version": "1.26.1",
   "description": "React components for self-review: embeddable code review UI with diff viewer and commenting",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` — it was writing an `.npmrc` with an empty `_authToken` that overrode the OIDC trusted publisher mechanism, causing the `PUT` to fail
- Remove runtime `npm pkg set` version patching from the publish step; versions are now managed by semantic-release
- Add `@semantic-release/npm` with `pkgRoot` for `packages/core` and `packages/react` so all three `package.json` files are bumped together on each release
- Sync `packages/core` and `packages/react` to `1.26.1` to match current app version

## Test plan

- [ ] Verify the next release correctly bumps all three `package.json` files in the release commit
- [ ] Verify `@self-review/core` and `@self-review/react` publish successfully via OIDC trusted publisher