### PR TITLE
fix(ci): add NO_COLOR=1 to releases

### DIFF
--- a/.github/workflows/release-darwin.yml
+++ b/.github/workflows/release-darwin.yml
@@ -17,6 +17,9 @@ concurrency:
   group: release-darwin-${{ inputs.tag }}
   cancel-in-progress: false
 
+env:
+  NO_COLOR: "1"
+
 jobs:
   release:
     name: macOS Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ concurrency:
   group: release-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
+env:
+  NO_COLOR: "1"
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Summary

- Adds `NO_COLOR=1` as a workflow-level env var to `release-darwin.yml` and `release.yml`
- Fixes the macOS build crash caused by `colorette@2.0.20` stack overflow in `replaceClose()` when processing large webpack output
- Prevents the same issue from occurring in the Linux workflow as the codebase grows

Closes #57 (build fix portion). Homebrew tap support tracked in #62.

## Test plan

- [ ] Merge this PR
- [ ] Trigger macOS workflow: `gh workflow run release-darwin.yml -f tag=v1.28.5`
- [ ] Verify the run completes and a `Self.Review-darwin-arm64-*.zip` asset appears on the v1.28.5 release