### PR TITLE
feat(cli): hide untracked files by default in --staged / --cached reviews, fixes #68

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -358,7 +358,7 @@ A top toolbar provides global controls:
 |---------|------|-------------|
 | View mode toggle | Segmented button | Switch between Split and Unified diff views |
 | Expand/Collapse all | Button | Expand or collapse all file sections at once |
-| Show/hide untracked | Toggle button | Show or hide untracked files (new files not yet added to git). Default: on. |
+| Show/hide untracked | Toggle button | Show or hide untracked files (new files not yet added to git). Default: on, except for `--staged` / `--cached` reviews where untracked files are hidden by default. |
 | Line wrap toggle | Toggle button | Wrap or unwrap long lines in the code content area. When off, long lines scroll horizontally. Default: on. |
 | Diff stats summary | Text | Shows total files changed, additions (+N in green), and deletions (-N in red). Computed from the parsed diff data. |
 | Theme toggle | Button or dropdown | Switch between Light, Dark, and System theme |
@@ -521,7 +521,9 @@ output-file: ./review.xml
 # Default output format (reserved for future multi-format support)
 output-format: xml
 
-# Show untracked files in the diff viewer: true or false
+# Show untracked files in the diff viewer: true or false.
+# In --staged / --cached reviews untracked files are hidden by default;
+# set this to `true` explicitly to show them from the start.
 show-untracked: true
 
 # Wrap long lines in the diff viewer: true or false
@@ -565,7 +567,10 @@ categories:
 # Default git diff arguments for this project
 default-diff-args: "--staged"
 
-# Show untracked files (new files not yet added to git): true or false
+# Show untracked files (new files not yet added to git): true or false.
+# When set to `true` explicitly, untracked files are shown from the start
+# for `--staged` / `--cached` reviews, which otherwise hide them by default
+# (they can still be revealed at runtime via the toolbar toggle).
 show-untracked: true
 
 # Wrap long lines in the diff viewer: true or false
@@ -613,7 +618,7 @@ The CLI runs `git diff` as a child process with the arguments provided by the us
 const diffOutput = execSync(`git diff ${userArgs.join(' ')}`, { cwd: process.cwd() });
 ```
 
-In addition to tracked changes, the application discovers **untracked files** (new files not yet added to git) via `git ls-files --others --exclude-standard`. For each untracked file, a synthetic unified diff is generated showing all lines as additions. These files are tagged with `isUntracked` internally and can be shown or hidden via a toolbar toggle (default: on) or the `show-untracked` configuration option. Untracked files respect `.gitignore` rules.
+In addition to tracked changes, the application discovers **untracked files** (new files not yet added to git) via `git ls-files --others --exclude-standard`. For each untracked file, a synthetic unified diff is generated showing all lines as additions. These files are tagged with `isUntracked` internally and can be shown or hidden via a toolbar toggle (default: on) or the `show-untracked` configuration option. Untracked files respect `.gitignore` rules. When the diff is invoked with `--staged` or `--cached` (index-vs-HEAD reviews), untracked files are **hidden by default** since they are not part of the index; they remain preloaded and can be revealed instantly by clicking the "Show New Files" toolbar toggle. Setting `show-untracked: true` explicitly in the YAML config overrides this default and shows them from the start.
 
 ### 9.2 Diff Parsing
 

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -71,7 +71,39 @@ show-untracked: false
 
       expect(config.diffView).toBe('unified');
       expect(config.showUntracked).toBe(false);
+      expect(config.showUntrackedExplicit).toBe(true);
       expect(config.theme).toBe('system'); // Still has default
+    });
+
+    it('keeps showUntrackedExplicit false when show-untracked is absent', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const config = loadConfig();
+
+      expect(config.showUntracked).toBe(true);
+      expect(config.showUntrackedExplicit).toBe(false);
+    });
+
+    it('sets showUntrackedExplicit true when show-untracked: true', () => {
+      const mockYaml = `show-untracked: true`;
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(mockYaml);
+
+      const config = loadConfig();
+
+      expect(config.showUntracked).toBe(true);
+      expect(config.showUntrackedExplicit).toBe(true);
+    });
+
+    it('keeps showUntrackedExplicit false when show-untracked has invalid type', () => {
+      const mockYaml = `show-untracked: "yes"`;
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(mockYaml);
+
+      const config = loadConfig();
+
+      expect(config.showUntracked).toBe(true); // default preserved
+      expect(config.showUntrackedExplicit).toBe(false);
     });
 
     it('merges user and project configs with project taking precedence', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -73,6 +73,7 @@ const defaults: AppConfig = {
   ],
   defaultDiffArgs: '',
   showUntracked: true,
+  showUntrackedExplicit: false,
   wordWrap: true,
   maxFiles: 500,
   maxTotalLines: 100000,
@@ -180,6 +181,7 @@ function loadYamlConfig(path: string): Partial<AppConfig> {
 
   if ('show-untracked' in raw && typeof raw['show-untracked'] === 'boolean') {
     config.showUntracked = raw['show-untracked'];
+    config.showUntrackedExplicit = true;
   }
 
   if ('word-wrap' in raw && typeof raw['word-wrap'] === 'boolean') {

--- a/packages/core/src/payload-sizing.test.ts
+++ b/packages/core/src/payload-sizing.test.ts
@@ -14,6 +14,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     categories: [],
     defaultDiffArgs: '',
     showUntracked: true,
+    showUntrackedExplicit: false,
     wordWrap: true,
     maxFiles: 500,
     maxTotalLines: 100000,

--- a/packages/react/src/context/ConfigContext.tsx
+++ b/packages/react/src/context/ConfigContext.tsx
@@ -50,6 +50,7 @@ export const defaultConfig: AppConfig = {
   ],
   defaultDiffArgs: '--staged',
   showUntracked: true,
+  showUntrackedExplicit: false,
   wordWrap: true,
   maxFiles: 500,
   maxTotalLines: 100000,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -106,6 +106,7 @@ export interface AppConfig {
   categories: CategoryDef[];
   defaultDiffArgs: string;
   showUntracked: boolean;
+  showUntrackedExplicit: boolean;
   wordWrap: boolean;
   maxFiles: number;
   maxTotalLines: number;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import { parseCliArgs, checkEarlyExit, normalizeGitDiffArgs } from './cli';
 import { loadGitDiffWithUntracked } from './git-diff-loader';
 import { scanDirectory, scanFile } from './directory-scanner';
 import { loadConfig } from './config';
+import { applyStagedUntrackedDefault } from './staged-untracked';
 import { createIgnoreFilter } from './ignore-filter';
 import { parseReviewXml } from './xml-parser';
 import { serializeReview } from './xml-serializer';
@@ -204,6 +205,12 @@ async function initializeApp() {
     // Normalize: insert `--` before bare path args so expand-context
     // never confuses them with revisions.
     gitDiffArgs = normalizeGitDiffArgs(gitDiffArgs);
+
+    // In staged-mode (--staged / --cached), hide untracked files by default
+    // unless the user explicitly opted in via `show-untracked: true` in YAML.
+    // Must run before any code reads appConfig.showUntracked or sends config
+    // to the renderer via setConfigData.
+    appConfig = applyStagedUntrackedDefault(appConfig, gitDiffArgs);
 
     // Phase 4: Determine startup mode
     const mode = determineMode(gitDiffArgs);

--- a/src/main/staged-untracked.test.ts
+++ b/src/main/staged-untracked.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import type { AppConfig } from '@self-review/types';
+import { applyStagedUntrackedDefault } from './staged-untracked';
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    theme: 'system',
+    diffView: 'split',
+    fontSize: 14,
+    outputFormat: 'xml',
+    outputFile: './review.xml',
+    ignore: [],
+    categories: [],
+    defaultDiffArgs: '',
+    showUntracked: true,
+    showUntrackedExplicit: false,
+    wordWrap: true,
+    maxFiles: 500,
+    maxTotalLines: 100000,
+    ...overrides,
+  };
+}
+
+describe('applyStagedUntrackedDefault', () => {
+  it('returns config unchanged when gitDiffArgs contains neither --staged nor --cached', () => {
+    const config = makeConfig({ showUntracked: true, showUntrackedExplicit: false });
+    const result = applyStagedUntrackedDefault(config, []);
+    expect(result.showUntracked).toBe(true);
+    expect(result).toBe(config);
+  });
+
+  it('returns config unchanged for a revision range like main..feature', () => {
+    const config = makeConfig({ showUntracked: true });
+    const result = applyStagedUntrackedDefault(config, ['main..feature']);
+    expect(result.showUntracked).toBe(true);
+    expect(result).toBe(config);
+  });
+
+  it('sets showUntracked to false when --staged is present and user has not explicitly opted in', () => {
+    const config = makeConfig({ showUntracked: true, showUntrackedExplicit: false });
+    const result = applyStagedUntrackedDefault(config, ['--staged']);
+    expect(result.showUntracked).toBe(false);
+    // Other fields should be preserved
+    expect(result.diffView).toBe(config.diffView);
+    expect(result.outputFile).toBe(config.outputFile);
+  });
+
+  it('sets showUntracked to false when --cached is present (alias for --staged)', () => {
+    const config = makeConfig({ showUntracked: true, showUntrackedExplicit: false });
+    const result = applyStagedUntrackedDefault(config, ['--cached']);
+    expect(result.showUntracked).toBe(false);
+  });
+
+  it('respects explicit user opt-in (showUntracked: true, showUntrackedExplicit: true) in staged mode', () => {
+    const config = makeConfig({ showUntracked: true, showUntrackedExplicit: true });
+    const result = applyStagedUntrackedDefault(config, ['--staged']);
+    expect(result.showUntracked).toBe(true);
+    expect(result).toBe(config);
+  });
+
+  it('leaves showUntracked: false unchanged when user opted out in staged mode', () => {
+    const config = makeConfig({ showUntracked: false, showUntrackedExplicit: true });
+    const result = applyStagedUntrackedDefault(config, ['--staged']);
+    expect(result.showUntracked).toBe(false);
+  });
+
+  it('detects staged mode alongside other flags (e.g. --staged combined with -w)', () => {
+    const config = makeConfig({ showUntracked: true, showUntrackedExplicit: false });
+    const result = applyStagedUntrackedDefault(config, ['--staged', '-w']);
+    expect(result.showUntracked).toBe(false);
+  });
+
+  it('detects staged mode when --cached is not the first arg', () => {
+    const config = makeConfig({ showUntracked: true, showUntrackedExplicit: false });
+    const result = applyStagedUntrackedDefault(config, ['-w', '--cached']);
+    expect(result.showUntracked).toBe(false);
+  });
+});

--- a/src/main/staged-untracked.ts
+++ b/src/main/staged-untracked.ts
@@ -1,0 +1,28 @@
+// src/main/staged-untracked.ts
+// Initial-config adjustment for staged-mode reviews.
+
+import type { AppConfig } from '@self-review/types';
+
+/**
+ * In staged-mode reviews (--staged / --cached), untracked files are not
+ * part of the index and should be hidden by default. If the user has
+ * explicitly opted in via `show-untracked: true` in their YAML config,
+ * respect that choice.
+ *
+ * Untracked files are still preloaded by the backend so that the toolbar
+ * toggle can reveal them instantly without re-running git.
+ */
+export function applyStagedUntrackedDefault(
+  config: AppConfig,
+  gitDiffArgs: string[]
+): AppConfig {
+  const stagedMode =
+    gitDiffArgs.includes('--staged') || gitDiffArgs.includes('--cached');
+  if (!stagedMode) return config;
+
+  const userExplicitOptIn =
+    config.showUntrackedExplicit && config.showUntracked;
+  if (userExplicitOptIn) return config;
+
+  return { ...config, showUntracked: false };
+}


### PR DESCRIPTION
Untracked files aren't part of the index, so listing them alongside staged changes conflates two review intents. The renderer already filters on config.showUntracked and the toolbar toggles it at runtime; this change only flips the initial value to false for --staged / --cached, unless the user set `show-untracked: true` explicitly.