### PR TITLE
fix: restore sticky file section headers

### DIFF
--- a/packages/react/src/components/DiffViewer/FileSection.tsx
+++ b/packages/react/src/components/DiffViewer/FileSection.tsx
@@ -125,7 +125,7 @@ export default function FileSection({
   return (
     <div
       ref={sectionRef}
-      className={`mx-2 mt-2 border border-border rounded-lg shadow-sm overflow-hidden${dragState ? ' select-none' : ''}`}
+      className={`mx-2 mt-2 border border-border rounded-lg shadow-sm${dragState ? ' select-none' : ''}`}
       data-file-path={filePath}
       data-testid={`file-section-${filePath}`}
     >

--- a/packages/react/src/components/DiffViewer/FileSectionBody.tsx
+++ b/packages/react/src/components/DiffViewer/FileSectionBody.tsx
@@ -22,7 +22,7 @@ export function FileSectionBody({
   contentAreaProps,
 }: FileSectionBodyProps) {
   return (
-    <div className='bg-background file-diff-content'>
+    <div className='bg-background file-diff-content rounded-b-lg overflow-hidden'>
       {/* File-level comments */}
       {fileComments.length > 0 && (
         <div className='p-3 space-y-2 bg-muted/20 border-b border-border'>

--- a/packages/react/src/components/DiffViewer/FileSectionHeader.tsx
+++ b/packages/react/src/components/DiffViewer/FileSectionHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import type { DiffFile, ReviewComment } from '@self-review/types';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
@@ -49,9 +49,25 @@ export function FileSectionHeader({
   const changeLabel =
     file.changeType.charAt(0).toUpperCase() + file.changeType.slice(1);
 
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isStuck, setIsStuck] = useState(false);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
   return (
+    <>
+    <div ref={sentinelRef} className='h-0 w-0' aria-hidden />
     <div
-      className='sticky top-0 z-10 flex items-center gap-2 h-10 px-3 bg-muted/80 backdrop-blur-sm border-b border-border cursor-pointer select-none'
+      className={`sticky top-0 z-10 flex items-center gap-2 h-10 px-3 bg-muted/80 backdrop-blur-sm border-b border-border cursor-pointer select-none${isStuck ? '' : ' rounded-t-lg'}`}
       data-testid={`file-header-${filePath}`}
       onClick={onToggle}
     >
@@ -170,5 +186,6 @@ export function FileSectionHeader({
         <TooltipContent>Add file comment</TooltipContent>
       </Tooltip>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Remove `overflow-hidden` from `FileSection` container which broke `position: sticky` on file headers
- Apply rounded corners directly to child elements: `FileSectionHeader` gets conditional `rounded-t-lg` (removed when stuck), `FileSectionBody` gets `rounded-b-lg overflow-hidden`
- Use IntersectionObserver sentinel to detect sticky state and toggle top border radius

## Test plan
- [x] Open a diff with files long enough to scroll
- [x] Verify file headers stick to viewport top when scrolling
- [x] Verify headers show rounded top corners when not stuck
- [x] Verify headers lose rounded top corners when stuck
- [x] Verify bottom corners of file sections remain rounded

Fixes #73