### PR TITLE
fix: prefill code suggestions with original code (#77)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -339,6 +339,7 @@ GitHub-style suggestions allow the reviewer to propose literal code replacements
 - **Activation:** Within any comment (line, multi-line, or file-level), the user can insert a suggestion block.
 - **Format:** A code block prefixed with `suggestion` (mimicking GitHub's triple-backtick suggestion syntax).
 - **Semantics:** The suggestion represents "replace the selected line(s) with this code." The original lines and the proposed replacement are both preserved in the output XML.
+- **Prefill:** When the user activates a suggestion, the proposed-code editor is prefilled with the original code so the user can edit in place rather than retyping (matching GitHub/GitLab behavior).
 - **Display:** Suggestions are rendered as a diff-within-a-diff: the original lines shown as removed (red), the suggestion shown as added (green), within the comment body.
 
 #### 5.4.5 Comment Categories / Tags

--- a/packages/react/src/components/Comments/CommentInput.tsx
+++ b/packages/react/src/components/Comments/CommentInput.tsx
@@ -229,7 +229,12 @@ export default function CommentInput({
               variant={showSuggestion ? 'secondary' : 'ghost'}
               size='sm'
               data-testid='add-suggestion-btn'
-              onClick={() => setShowSuggestion(!showSuggestion)}
+              onClick={() => {
+                if (!showSuggestion && proposedCode.length === 0) {
+                  setProposedCode(originalCode);
+                }
+                setShowSuggestion(!showSuggestion);
+              }}
               className='h-7 gap-1.5 text-xs'
             >
               <Code2 className='h-3.5 w-3.5' />

--- a/tests/webapp-features/04-suggestions.feature
+++ b/tests/webapp-features/04-suggestions.feature
@@ -14,3 +14,13 @@ Feature: Webapp Code Suggestions
     When I type "const fixed = true;" in the proposed code editor
     And I click "Comment"
     Then the displayed comment should show a suggestion block
+
+  Scenario: Editing a comment with a suggestion shows the saved proposed code, not the original
+    When I click the "+" icon on new line 5 in "src/auth/login.ts"
+    And I type "Suggestion comment" in the comment input
+    And I click "Add suggestion"
+    And I type "const fixed = true;" in the proposed code editor
+    And I click "Comment"
+    Then the displayed comment should show a suggestion block
+    When I click "Edit" on that comment
+    Then the proposed code editor should contain "const fixed = true;"

--- a/tests/webapp-steps/04-suggestions.steps.ts
+++ b/tests/webapp-steps/04-suggestions.steps.ts
@@ -24,10 +24,25 @@ Then(
     await expect(
       page.locator('[data-testid="suggestion-original"]')
     ).toBeVisible();
-    const value = await page
+    const original = await page
       .locator('[data-testid="suggestion-original"] textarea')
       .inputValue();
-    expect(value.length).toBeGreaterThan(0);
+    expect(original.length).toBeGreaterThan(0);
+    const proposed = await page
+      .locator('[data-testid="suggestion-proposed"] textarea')
+      .inputValue();
+    expect(proposed).toBe(original);
+  }
+);
+
+Then(
+  'the proposed code editor should contain {string}',
+  async ({}, expected: string) => {
+    const page = getPage();
+    const value = await page
+      .locator('[data-testid="suggestion-proposed"] textarea')
+      .inputValue();
+    expect(value).toBe(expected);
   }
 );
 


### PR DESCRIPTION
When activating a suggestion, prefill the proposed-code editor with the original code so it can be edited in place. When editing a comment that already has a suggestion, keep the saved proposed code instead of overwriting it.