### PR TITLE
fix: treat empty .self-review.yaml as "use defaults" (#79)

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -215,6 +215,39 @@ diff-view: invalid-view
       );
     });
 
+    it('treats an empty config file as "use defaults" without warning', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('');
+
+      const config = loadConfig();
+
+      expect(config.theme).toBe('system');
+      expect(config.diffView).toBe('split');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('treats a config file containing only `null` as "use defaults" without warning', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('null\n');
+
+      const config = loadConfig();
+
+      expect(config.theme).toBe('system');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('warns when YAML parses to a non-object (e.g. an array at the top level)', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('- one\n- two\n');
+
+      const config = loadConfig();
+
+      expect(config.theme).toBe('system');
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid YAML format')
+      );
+    });
+
     it('loads ignore patterns from config', () => {
       const mockYaml = `
 ignore:

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -120,7 +120,12 @@ function loadYamlConfig(path: string): Partial<AppConfig> {
   const content = readFileSync(path, 'utf-8');
   const raw = parseYaml(content);
 
-  if (!raw || typeof raw !== 'object') {
+  // An empty file (or one containing only `null`) is a valid "use defaults" state.
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('Invalid YAML format');
   }
 


### PR DESCRIPTION
An empty config file (or one containing only `null`) is a legitimate "no overrides" state, not malformed input. Stop logging the spurious "Invalid YAML format" warning on startup. Still warns when YAML parses to a non-object (e.g. a top-level array).