### PR TITLE
style(diff-viewer): blue-tint hunk separator and expand-context bars

### DIFF
--- a/packages/react/src/components/DiffViewer/ExpandContextBar.tsx
+++ b/packages/react/src/components/DiffViewer/ExpandContextBar.tsx
@@ -31,7 +31,7 @@ export default function ExpandContextBar({
     <Tooltip>
       <TooltipTrigger asChild>
         <button
-          className='flex items-center justify-center w-5 h-5 rounded-sm text-muted-foreground/60 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-600/10 transition-colors cursor-pointer'
+          className='flex items-center justify-center w-5 h-5 rounded-sm text-blue-700/70 dark:text-blue-300/70 hover:text-blue-700 dark:hover:text-blue-200 hover:bg-blue-500/20 dark:hover:bg-blue-400/20 transition-colors cursor-pointer'
           onClick={e => {
             e.stopPropagation();
             onExpand(direction, hunkIndex, position);
@@ -46,7 +46,7 @@ export default function ExpandContextBar({
   );
 
   return (
-    <div className='expand-context-bar flex items-center h-[26px] bg-accent/30 border-y border-border/30 text-muted-foreground select-none'>
+    <div className='expand-context-bar flex items-center h-[26px] bg-blue-500/10 dark:bg-blue-400/15 text-blue-700 dark:text-blue-300 select-none'>
       {/* Gutter area — matches line number column width */}
       <div className='w-10 flex-shrink-0 flex items-center justify-center gap-0.5'>
         {loading ? (
@@ -66,7 +66,7 @@ export default function ExpandContextBar({
       <div className='flex-1 px-2'>
         {showSingleButton ? (
           <button
-            className='text-[11px] text-muted-foreground/60 hover:text-blue-600 dark:hover:text-blue-400 transition-colors cursor-pointer'
+            className='text-[11px] text-blue-700/70 dark:text-blue-300/70 hover:text-blue-700 dark:hover:text-blue-200 transition-colors cursor-pointer'
             onClick={() => onExpand('all', hunkIndex, position)}
             disabled={loading}
           >
@@ -74,7 +74,7 @@ export default function ExpandContextBar({
           </button>
         ) : (
           <button
-            className='text-[11px] text-muted-foreground/60 hover:text-blue-600 dark:hover:text-blue-400 transition-colors cursor-pointer'
+            className='text-[11px] text-blue-700/70 dark:text-blue-300/70 hover:text-blue-700 dark:hover:text-blue-200 transition-colors cursor-pointer'
             onClick={() => onExpand('all', hunkIndex, position)}
             disabled={loading}
           >

--- a/packages/react/src/components/DiffViewer/HunkHeader.tsx
+++ b/packages/react/src/components/DiffViewer/HunkHeader.tsx
@@ -6,7 +6,7 @@ export interface HunkHeaderProps {
 
 export default function HunkHeader({ header }: HunkHeaderProps) {
   return (
-    <div className='hunk-header flex items-center h-7 px-3 text-muted-foreground/70 text-xs font-mono border-t border-border/30'>
+    <div className='hunk-header flex items-center h-7 px-3 text-xs font-mono bg-blue-500/10 dark:bg-blue-400/15 text-blue-700 dark:text-blue-300'>
       {header}
     </div>
   );


### PR DESCRIPTION
## Summary

- Drop the muted top/y borders on `HunkHeader` and `ExpandContextBar` and apply a shared blue background tint with light- and dark-theme variants, so both bars read as semantically distinct from surrounding diff rows and visually related to each other.
- Update the inner expand-context icon and text buttons to blue-tinted defaults with brighter blue hover states so they remain legible on the new background.
- Stays within the existing `blue-500` / `blue-400` palette already used for the renamed-file badge (`packages/react/src/utils/diff-styles.ts:42`) and the prior expand-context hover state.

Closes #83

## Test plan

- [ ] Verify in light theme: hunk separator and expand-context bar both show a soft blue tint with no top/y border.
- [ ] Verify in dark theme: same bars use the slightly stronger dark-mode blue tint and remain legible.
- [ ] Confirm both Split and Unified view modes pick up the new styling.
- [ ] Hover over expand-context icon and text buttons; confirm color brightens and icon button gets a stronger blue background hover.
- [ ] `npm run lint` and `npm run test:unit` pass.