### PR TITLE
fix(file-tree): truncate overflowing filenames so right-side controls stay visible

### DIFF
--- a/packages/react/src/components/TruncatedPath.tsx
+++ b/packages/react/src/components/TruncatedPath.tsx
@@ -24,7 +24,7 @@ export default function TruncatedPath({ path, className = '' }: TruncatedPathPro
           {dir}
         </span>
       )}
-      <span className='flex-shrink-0 whitespace-nowrap'>
+      <span className='truncate flex-shrink-0 max-w-full'>
         {fileName}
       </span>
     </span>


### PR DESCRIPTION
## Summary
- Long filenames in narrow file-tree rows previously bled past the row and visually covered the diff stats badge and the mark-reviewed toggle.
- Updated `TruncatedPath` so the filename span uses `flex-shrink: 0 + max-width: 100% + truncate`. The directory is now the only shrinkable item and fully collapses first; the filename only ellipsizes once it would otherwise exceed the row width.

Closes #85

## Test plan
- [x] Open a diff with deep paths (e.g. `packages/.../payload-sizing.test.ts`); narrow the file-tree pane and confirm the diff stats badge and mark-reviewed circle remain fully visible at every width.
- [x] Confirm parent folders still collapse first (`packag…AGENTS.md` style) before the filename starts ellipsizing.
- [x] Confirm short filenames in deep dirs behave as before.
- [x] `npm run test:unit` passes.