### PR TITLE
fix(hints): hide non-matching Vimium-style hint labels as the user types

### DIFF
--- a/packages/react/src/components/HintOverlay.tsx
+++ b/packages/react/src/components/HintOverlay.tsx
@@ -13,7 +13,11 @@ interface HintOverlayProps {
 }
 
 export function HintOverlay({ hints, inputBuffer }: HintOverlayProps) {
-  if (hints.length === 0) return null;
+  const visibleHints = inputBuffer
+    ? hints.filter((h) => h.label.startsWith(inputBuffer))
+    : hints;
+
+  if (visibleHints.length === 0) return null;
 
   return createPortal(
     <div
@@ -24,7 +28,7 @@ export function HintOverlay({ hints, inputBuffer }: HintOverlayProps) {
         zIndex: 9999,
       }}
     >
-      {hints.map((hint) => (
+      {visibleHints.map((hint) => (
         <span
           key={hint.label}
           style={{


### PR DESCRIPTION
## Summary

- Filter the hint overlay by the current input buffer so labels whose prefix no longer matches disappear as soon as the user types a character (matches Vimium behavior).
- The matching logic in `useKeyboardNavigation` already tracked the buffer and rejected non-prefix keys; only the overlay rendering needed updating.

Closes #87

## Test plan

- [ ] Open self-review with a diff containing many changed lines
- [ ] Press `f` and confirm yellow labels appear over diff lines
- [ ] Type the first character of some labels and confirm non-matching labels disappear immediately
- [ ] Type a non-existent first character and confirm the overlay dismisses
- [ ] Press `g` over the file tree and verify the same behavior for file hints