### PR TITLE
fix(file-tree): replace nested button in viewed-toggle with span role=button

### DIFF
--- a/packages/react/src/components/FileTreeEntry.tsx
+++ b/packages/react/src/components/FileTreeEntry.tsx
@@ -72,11 +72,20 @@ export function FileTreeEntry({
               )}
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <button
+                  <span
                     data-testid={`viewed-toggle-${filePath}`}
+                    role='button'
+                    tabIndex={0}
                     onClick={e => {
                       e.stopPropagation();
                       onToggleViewed(filePath);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        onToggleViewed(filePath);
+                      }
                     }}
                     className='inline-flex items-center justify-center h-5 w-5 rounded-sm hover:bg-accent/80 transition-colors cursor-pointer'
                   >
@@ -85,7 +94,7 @@ export function FileTreeEntry({
                     ) : (
                       <CircleDashed className='h-3.5 w-3.5 text-muted-foreground/60' />
                     )}
-                  </button>
+                  </span>
                 </TooltipTrigger>
                 <TooltipContent side='right'>
                   {viewed ? 'Mark as needs review' : 'Mark as done reviewing'}


### PR DESCRIPTION
## Summary
- Replace the inner `<button>` (viewed-toggle) inside the file-row `<button>` with `<span role="button" tabIndex={0}>` to remove the React `validateDOMNesting` warning.
- Preserve keyboard activation by adding an `onKeyDown` handler that triggers the toggle on Enter/Space (with `preventDefault` + `stopPropagation`).

Closes #89

## Test plan
- [ ] Open a diff with multiple files; confirm no `validateDOMNesting` warning appears in the console.
- [ ] Click the viewed-toggle: it toggles and does not trigger the row click (no scroll-to-file).
- [ ] Focus the viewed-toggle via keyboard and press Enter, then Space: each toggles the viewed state.
- [ ] Tooltip on the toggle still appears on hover/focus.