### PR TITLE
feat(react): expose adapter prop on SingleFileReview

### DIFF
--- a/packages/react/src/SingleFileReview.test.tsx
+++ b/packages/react/src/SingleFileReview.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { DiffFile } from '@self-review/types';
+import type { ReviewAdapter } from './adapter';
+
+// jsdom does not implement these browser APIs that the inner providers touch
+// during their passive effects. Without the polyfills, the render call surfaces
+// IntersectionObserver / matchMedia errors even though we only care about the
+// adapter captured at the outer ReviewAdapterProvider.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+}
+(globalThis as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+let capturedAdapter: ReviewAdapter | null = null;
+
+vi.mock('./context/ReviewAdapterContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./context/ReviewAdapterContext')>();
+  return {
+    ...actual,
+    ReviewAdapterProvider: ({
+      adapter,
+      children,
+    }: {
+      adapter: ReviewAdapter;
+      children: React.ReactNode;
+    }) => {
+      capturedAdapter = adapter;
+      return <>{children}</>;
+    },
+  };
+});
+
+vi.mock('./components/DiffViewer/FileSection', () => ({
+  default: () => null,
+}));
+
+import { SingleFileReview } from './SingleFileReview';
+
+const file: DiffFile = {
+  oldPath: 'src/foo.ts',
+  newPath: 'src/foo.ts',
+  changeType: 'modified',
+  isBinary: false,
+  hunks: [],
+};
+
+describe('SingleFileReview adapter merge', () => {
+  beforeEach(() => {
+    capturedAdapter = null;
+  });
+
+  it('invokes consumer-supplied expandContext via the merged adapter', async () => {
+    const expandContext = vi.fn().mockResolvedValue({ hunks: [], totalLines: 0 });
+
+    render(<SingleFileReview file={file} adapter={{ expandContext }} />);
+
+    expect(capturedAdapter).not.toBeNull();
+    await capturedAdapter!.expandContext!({ filePath: 'src/foo.ts', contextLines: 5 });
+
+    expect(expandContext).toHaveBeenCalledWith({
+      filePath: 'src/foo.ts',
+      contextLines: 5,
+    });
+  });
+
+  it('ignores consumer-supplied loadDiff in favor of the internal one', async () => {
+    const consumerLoadDiff = vi.fn().mockResolvedValue({ files: [], source: undefined });
+
+    render(<SingleFileReview file={file} adapter={{ loadDiff: consumerLoadDiff }} />);
+
+    expect(capturedAdapter).not.toBeNull();
+    const result = await capturedAdapter!.loadDiff();
+
+    expect(consumerLoadDiff).not.toHaveBeenCalled();
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0]).toBe(file);
+  });
+
+  it('exposes only loadDiff when no adapter prop is supplied', () => {
+    render(<SingleFileReview file={file} />);
+
+    expect(capturedAdapter).not.toBeNull();
+    expect(typeof capturedAdapter!.loadDiff).toBe('function');
+    expect(capturedAdapter!.expandContext).toBeUndefined();
+    expect(capturedAdapter!.loadFileContent).toBeUndefined();
+    expect(capturedAdapter!.loadImage).toBeUndefined();
+    expect(capturedAdapter!.readAttachment).toBeUndefined();
+    expect(capturedAdapter!.loadResumedComments).toBeUndefined();
+    expect(capturedAdapter!.submitReview).toBeUndefined();
+    expect(capturedAdapter!.changeOutputPath).toBeUndefined();
+  });
+});

--- a/packages/react/src/SingleFileReview.tsx
+++ b/packages/react/src/SingleFileReview.tsx
@@ -20,6 +20,16 @@ export interface SingleFileReviewProps {
   config?: Partial<AppConfig>;
   /** Called when review comments change. */
   onReviewChange?: (comments: ReviewComment[]) => void;
+  /**
+   * Optional partial `ReviewAdapter`. Consumers use this to wire optional adapter methods
+   * such as `expandContext`, `loadFileContent`, `loadImage`, `readAttachment`,
+   * `loadResumedComments`, `submitReview`, and `changeOutputPath`.
+   *
+   * Note: a consumer-supplied `loadDiff` is intentionally ignored — `file` and `source`
+   * are the source of truth in single-file mode. Memoize this object on the consumer side
+   * to avoid unnecessary re-renders, the same way `ReviewPanel` expects.
+   */
+  adapter?: Partial<ReviewAdapter>;
   /** CSS class applied to the root container. */
   className?: string;
   /** Default view mode for markdown files: 'raw' shows diff, 'rendered' shows rendered markdown. */
@@ -68,21 +78,25 @@ export const SingleFileReview = forwardRef<ReviewHandle, SingleFileReviewProps>(
     source,
     config,
     onReviewChange,
+    adapter,
     className,
     defaultViewMode = 'unified',
     prismLightCss,
     prismDarkCss,
   }, ref) {
-    // Create a minimal adapter that provides the single file
-    const adapter: ReviewAdapter = useMemo(() => ({
+    // Merge consumer-supplied adapter under the internally-generated loadDiff.
+    // Spread order is load-bearing: the internal loadDiff must always win, since
+    // file/source are the source of truth in single-file mode.
+    const mergedAdapter: ReviewAdapter = useMemo(() => ({
+      ...adapter,
       loadDiff: async (): Promise<DiffLoadPayload> => ({
         files: [file],
         source: source || { type: 'file', sourcePath: file.newPath || file.oldPath },
       }),
-    }), [file, source]);
+    }), [file, source, adapter]);
 
     return (
-      <ReviewAdapterProvider adapter={adapter}>
+      <ReviewAdapterProvider adapter={mergedAdapter}>
         <ConfigProvider
           initialConfig={{ ...config, diffView: defaultViewMode }}
           prismLightCss={prismLightCss}


### PR DESCRIPTION
## Summary

- Adds an optional `adapter?: Partial<ReviewAdapter>` prop on `SingleFileReview`, reaching parity with `ReviewPanel`. Consumers can now wire optional adapter methods (`expandContext`, `loadFileContent`, `loadImage`, `readAttachment`, `loadResumedComments`, `submitReview`, `changeOutputPath`).
- The internally-generated `loadDiff` is preserved by spread order so `file`/`source` remain the single source of truth in single-file mode; a consumer-supplied `loadDiff` is intentionally ignored.
- Resolves the silent no-op on the "Show N hidden lines" affordance for `SingleFileReview` consumers.

Closes #92.

## Test plan

- [x] `npm run test:unit` — 123 tests pass (3 added in `packages/react/src/SingleFileReview.test.tsx`)
- [x] `npx eslint .` — clean
- [x] `npx tsc --noEmit` (in `packages/react`) — clean
- [x] `npm run build` (in `packages/react`) — `dist/index.d.ts` declares `adapter?: Partial<ReviewAdapter>` on `SingleFileReviewProps`
- [ ] Downstream verification in Dalia: wire `expandContext` on a `SingleFileReview` integration and confirm "Show N hidden lines" invokes it