### PR TITLE
feat(react): add adapter prop to SingleFileReview and move view toggle

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -234,6 +234,7 @@ A vertical list of all files in the diff, displayed as a flat list with file pat
 - Clicking a file scrolls the diff viewer to that file.
 - The currently visible file in the diff viewer is highlighted in the file tree.
 - File order matches the order returned by `git diff` (alphabetical by default).
+- The header includes a Split/Unified diff-view toggle that controls the diff viewer's render mode.
 
 **File search/filter:**
 
@@ -280,7 +281,7 @@ Each file in the diff is rendered as a collapsible section:
 
 #### 5.3.2 Diff View Modes
 
-Two view modes, togglable via a control in the toolbar:
+Two view modes, togglable via a control in the file tree header:
 
 - **Split view (side-by-side):** Old file on the left, new file on the right. Lines are aligned. This is the default.
 - **Unified view:** Single column showing both old and new lines interleaved, with `-` and `+` prefixes. Traditional unified diff format.
@@ -357,7 +358,6 @@ A top toolbar provides global controls:
 
 | Control | Type | Description |
 |---------|------|-------------|
-| View mode toggle | Segmented button | Switch between Split and Unified diff views |
 | Expand/Collapse all | Button | Expand or collapse all file sections at once |
 | Show/hide untracked | Toggle button | Show or hide untracked files (new files not yet added to git). Default: on, except for `--staged` / `--cached` reviews where untracked files are hidden by default. |
 | Line wrap toggle | Toggle button | Wrap or unwrap long lines in the code content area. When off, long lines scroll horizontally. Default: on. |

--- a/packages/react/src/SingleFileReview.test.tsx
+++ b/packages/react/src/SingleFileReview.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { DiffFile } from '@self-review/types';
+import type { ReviewAdapter } from './adapter';
+
+// jsdom does not implement these browser APIs that the inner providers touch
+// during their passive effects. Without the polyfills, the render call surfaces
+// IntersectionObserver / matchMedia errors even though we only care about the
+// adapter captured at the outer ReviewAdapterProvider.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+}
+(globalThis as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+let capturedAdapter: ReviewAdapter | null = null;
+
+vi.mock('./context/ReviewAdapterContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./context/ReviewAdapterContext')>();
+  return {
+    ...actual,
+    ReviewAdapterProvider: ({
+      adapter,
+      children,
+    }: {
+      adapter: ReviewAdapter;
+      children: React.ReactNode;
+    }) => {
+      capturedAdapter = adapter;
+      return <>{children}</>;
+    },
+  };
+});
+
+vi.mock('./components/DiffViewer/FileSection', () => ({
+  default: () => null,
+}));
+
+import { SingleFileReview } from './SingleFileReview';
+
+const file: DiffFile = {
+  oldPath: 'src/foo.ts',
+  newPath: 'src/foo.ts',
+  changeType: 'modified',
+  isBinary: false,
+  hunks: [],
+};
+
+describe('SingleFileReview adapter merge', () => {
+  beforeEach(() => {
+    capturedAdapter = null;
+  });
+
+  it('invokes consumer-supplied expandContext via the merged adapter', async () => {
+    const expandContext = vi.fn().mockResolvedValue({ hunks: [], totalLines: 0 });
+
+    render(<SingleFileReview file={file} adapter={{ expandContext }} />);
+
+    expect(capturedAdapter).not.toBeNull();
+    await capturedAdapter!.expandContext!({ filePath: 'src/foo.ts', contextLines: 5 });
+
+    expect(expandContext).toHaveBeenCalledWith({
+      filePath: 'src/foo.ts',
+      contextLines: 5,
+    });
+  });
+
+  it('ignores consumer-supplied loadDiff in favor of the internal one', async () => {
+    const consumerLoadDiff = vi.fn().mockResolvedValue({ files: [], source: undefined });
+
+    render(<SingleFileReview file={file} adapter={{ loadDiff: consumerLoadDiff }} />);
+
+    expect(capturedAdapter).not.toBeNull();
+    const result = await capturedAdapter!.loadDiff();
+
+    expect(consumerLoadDiff).not.toHaveBeenCalled();
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0]).toBe(file);
+  });
+
+  it('exposes only loadDiff when no adapter prop is supplied', () => {
+    render(<SingleFileReview file={file} />);
+
+    expect(capturedAdapter).not.toBeNull();
+    expect(typeof capturedAdapter!.loadDiff).toBe('function');
+    expect(capturedAdapter!.expandContext).toBeUndefined();
+    expect(capturedAdapter!.loadFileContent).toBeUndefined();
+    expect(capturedAdapter!.loadImage).toBeUndefined();
+    expect(capturedAdapter!.readAttachment).toBeUndefined();
+    expect(capturedAdapter!.loadResumedComments).toBeUndefined();
+    expect(capturedAdapter!.submitReview).toBeUndefined();
+    expect(capturedAdapter!.changeOutputPath).toBeUndefined();
+  });
+});

--- a/packages/react/src/SingleFileReview.tsx
+++ b/packages/react/src/SingleFileReview.tsx
@@ -20,6 +20,16 @@ export interface SingleFileReviewProps {
   config?: Partial<AppConfig>;
   /** Called when review comments change. */
   onReviewChange?: (comments: ReviewComment[]) => void;
+  /**
+   * Optional partial `ReviewAdapter`. Consumers use this to wire optional adapter methods
+   * such as `expandContext`, `loadFileContent`, `loadImage`, `readAttachment`,
+   * `loadResumedComments`, `submitReview`, and `changeOutputPath`.
+   *
+   * Note: a consumer-supplied `loadDiff` is intentionally ignored — `file` and `source`
+   * are the source of truth in single-file mode. Memoize this object on the consumer side
+   * to avoid unnecessary re-renders, the same way `ReviewPanel` expects.
+   */
+  adapter?: Partial<ReviewAdapter>;
   /** CSS class applied to the root container. */
   className?: string;
   /** Default view mode for markdown files: 'raw' shows diff, 'rendered' shows rendered markdown. */
@@ -68,21 +78,25 @@ export const SingleFileReview = forwardRef<ReviewHandle, SingleFileReviewProps>(
     source,
     config,
     onReviewChange,
+    adapter,
     className,
     defaultViewMode = 'unified',
     prismLightCss,
     prismDarkCss,
   }, ref) {
-    // Create a minimal adapter that provides the single file
-    const adapter: ReviewAdapter = useMemo(() => ({
+    // Merge consumer-supplied adapter under the internally-generated loadDiff.
+    // Spread order is load-bearing: the internal loadDiff must always win, since
+    // file/source are the source of truth in single-file mode.
+    const mergedAdapter: ReviewAdapter = useMemo(() => ({
+      ...adapter,
       loadDiff: async (): Promise<DiffLoadPayload> => ({
         files: [file],
         source: source || { type: 'file', sourcePath: file.newPath || file.oldPath },
       }),
-    }), [file, source]);
+    }), [file, source, adapter]);
 
     return (
-      <ReviewAdapterProvider adapter={adapter}>
+      <ReviewAdapterProvider adapter={mergedAdapter}>
         <ConfigProvider
           initialConfig={{ ...config, diffView: defaultViewMode }}
           prismLightCss={prismLightCss}

--- a/packages/react/src/components/FileTree.test.tsx
+++ b/packages/react/src/components/FileTree.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { DiffFile } from '@self-review/types';
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+}
+(globalThis as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+import FileTree from './FileTree';
+import { ConfigProvider, useConfig } from '../context/ConfigContext';
+import { ReviewProvider } from '../context/ReviewContext';
+import { DiffNavigationProvider } from '../context/DiffNavigationContext';
+
+const file: DiffFile = {
+  oldPath: 'src/foo.ts',
+  newPath: 'src/foo.ts',
+  changeType: 'modified',
+  isBinary: false,
+  hunks: [],
+};
+
+function ConfigProbe() {
+  const { config } = useConfig();
+  return <div data-testid='probe-diff-view'>{config.diffView}</div>;
+}
+
+function renderStandalone(initialDiffView: 'split' | 'unified' = 'split') {
+  return render(
+    <ConfigProvider initialConfig={{ diffView: initialDiffView }}>
+      <ReviewProvider initialFiles={[file]}>
+        <DiffNavigationProvider>
+          <FileTree />
+          <ConfigProbe />
+        </DiffNavigationProvider>
+      </ReviewProvider>
+    </ConfigProvider>
+  );
+}
+
+describe('FileTree view-mode toggle', () => {
+  it('renders both view-mode toggle items in the file tree header', () => {
+    renderStandalone();
+    expect(screen.queryByTestId('view-mode-split')).not.toBeNull();
+    expect(screen.queryByTestId('view-mode-unified')).not.toBeNull();
+  });
+
+  it('marks the split item as active when config.diffView is "split"', () => {
+    renderStandalone('split');
+    expect(screen.getByTestId('view-mode-split').hasAttribute('data-pressed')).toBe(true);
+    expect(screen.getByTestId('view-mode-unified').hasAttribute('data-pressed')).toBe(false);
+  });
+
+  it('dispatches updateConfig({ diffView: "unified" }) when the unified item is clicked', () => {
+    renderStandalone('split');
+    expect(screen.getByTestId('probe-diff-view').textContent).toBe('split');
+    fireEvent.click(screen.getByTestId('view-mode-unified'));
+    expect(screen.getByTestId('probe-diff-view').textContent).toBe('unified');
+  });
+});

--- a/packages/react/src/components/FileTree.tsx
+++ b/packages/react/src/components/FileTree.tsx
@@ -7,14 +7,15 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Badge } from './ui/badge';
 import { Separator } from './ui/separator';
+import { ToggleGroup, ToggleGroupItem } from './ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
-import { Search, ChevronsDownUp, ChevronsUpDown, Keyboard, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Search, ChevronsDownUp, ChevronsUpDown, Keyboard, CheckCircle2, AlertCircle, Columns2, AlignJustify } from 'lucide-react';
 import TruncatedPath from './TruncatedPath';
 import { FileTreeEntry } from './FileTreeEntry';
 
 export default function FileTree() {
   const { diffFiles, files, toggleViewed } = useReview();
-  const { outputPathInfo, setOutputPathInfo } = useConfig();
+  const { config, updateConfig, outputPathInfo, setOutputPathInfo } = useConfig();
   const { activeFilePath, scrollToFile } = useDiffNavigationContext();
   const adapter = useAdapter();
   const [searchQuery, setSearchQuery] = useState('');
@@ -26,6 +27,12 @@ export default function FileTree() {
     const result = await adapter.changeOutputPath();
     if (result) {
       setOutputPathInfo(result);
+    }
+  };
+
+  const handleViewModeChange = (value: string) => {
+    if (value === 'split' || value === 'unified') {
+      updateConfig({ diffView: value });
     }
   };
 
@@ -64,6 +71,41 @@ export default function FileTree() {
             Changed files
           </span>
           <div className='flex items-center gap-1'>
+            <ToggleGroup
+              type='single'
+              variant='outline'
+              size='sm'
+              value={config.diffView}
+              onValueChange={handleViewModeChange}
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToggleGroupItem
+                    value='split'
+                    data-testid='view-mode-split'
+                    className='h-5 w-5 p-0'
+                  >
+                    <Columns2 className='h-3.5 w-3.5' />
+                    <span className='sr-only'>Split view</span>
+                  </ToggleGroupItem>
+                </TooltipTrigger>
+                <TooltipContent>Side-by-side view</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToggleGroupItem
+                    value='unified'
+                    data-testid='view-mode-unified'
+                    className='h-5 w-5 p-0'
+                  >
+                    <AlignJustify className='h-3.5 w-3.5' />
+                    <span className='sr-only'>Unified view</span>
+                  </ToggleGroupItem>
+                </TooltipTrigger>
+                <TooltipContent>Unified view</TooltipContent>
+              </Tooltip>
+            </ToggleGroup>
+            <Separator orientation='vertical' className='h-4' />
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button

--- a/packages/react/src/components/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar.tsx
@@ -6,8 +6,6 @@ import { ToggleGroup, ToggleGroupItem } from './ui/toggle-group';
 import { Separator } from './ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import {
-  Columns2,
-  AlignJustify,
   Sun,
   Moon,
   Monitor,
@@ -57,12 +55,6 @@ export default function Toolbar({ onFinishReview }: ToolbarProps = {}) {
     document.dispatchEvent(event);
   };
 
-  const handleViewModeChange = (value: string) => {
-    if (value === 'split' || value === 'unified') {
-      updateConfig({ diffView: value });
-    }
-  };
-
   const handleThemeChange = (theme: 'light' | 'dark' | 'system') => {
     updateConfig({ theme });
   };
@@ -106,43 +98,6 @@ export default function Toolbar({ onFinishReview }: ToolbarProps = {}) {
             <Separator orientation='vertical' className='h-5' />
           </>
         )}
-
-        <ToggleGroup
-          type='single'
-          variant='outline'
-          size='sm'
-          value={config.diffView}
-          onValueChange={handleViewModeChange}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToggleGroupItem
-                value='split'
-                data-testid='view-mode-split'
-                className='gap-1.5 px-2.5'
-              >
-                <Columns2 className='h-3.5 w-3.5' />
-                <span className='text-xs'>Split</span>
-              </ToggleGroupItem>
-            </TooltipTrigger>
-            <TooltipContent>Side-by-side view</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToggleGroupItem
-                value='unified'
-                data-testid='view-mode-unified'
-                className='gap-1.5 px-2.5'
-              >
-                <AlignJustify className='h-3.5 w-3.5' />
-                <span className='text-xs'>Unified</span>
-              </ToggleGroupItem>
-            </TooltipTrigger>
-            <TooltipContent>Unified view</TooltipContent>
-          </Tooltip>
-        </ToggleGroup>
-
-        <Separator orientation='vertical' className='h-5' />
 
         <Tooltip>
           <TooltipTrigger asChild>

--- a/tests/webapp-features/05-view-modes-and-toolbar.feature
+++ b/tests/webapp-features/05-view-modes-and-toolbar.feature
@@ -11,13 +11,13 @@ Feature: Webapp View Modes and Toolbar
     And the split view should show two columns
 
   Scenario: Switch to unified view mode
-    When I click the "Unified" view mode toggle in the toolbar
+    When I click the "Unified" view mode toggle in the file tree
     Then the diff viewer should be in "unified" view mode
     And the unified view should show a single column layout
 
   Scenario: Switch back to split view mode
-    When I click the "Unified" view mode toggle in the toolbar
-    And I click the "Split" view mode toggle in the toolbar
+    When I click the "Unified" view mode toggle in the file tree
+    And I click the "Split" view mode toggle in the file tree
     Then the diff viewer should be in "split" view mode
 
   Scenario: Collapse all file sections

--- a/tests/webapp-steps/05-view-modes-and-toolbar.steps.ts
+++ b/tests/webapp-steps/05-view-modes-and-toolbar.steps.ts
@@ -8,7 +8,7 @@ import { getPage } from './app';
 const { When, Then } = createBdd();
 
 When(
-  'I click the {string} view mode toggle in the toolbar',
+  'I click the {string} view mode toggle in the file tree',
   async ({}, mode: string) => {
     const page = getPage();
     if (mode === 'Unified') {


### PR DESCRIPTION
## Summary
- Expose an `adapter` prop on `SingleFileReview` so consumers can wire optional `ReviewAdapter` methods (`expandContext`, `loadFileContent`, `loadImage`, `readAttachment`, `loadResumedComments`, `submitReview`, `changeOutputPath`). A consumer-supplied `loadDiff` is intentionally ignored — `file`/`source` remain the source of truth.
- Move the Split/Unified diff-view toggle out of the global `Toolbar` and into the `FileTree` header, where it sits closer to the file list it controls.
- Update the PRD and the view-modes feature/steps to reflect the new toggle location.

## Test plan
- [x] `npm run test:unit` (126 passed)
- [ ] Manually verify the Split/Unified toggle in `FileTree` header switches diff modes
- [ ] Manually verify a consumer-supplied adapter on `SingleFileReview` is honored for non-`loadDiff` methods