### PR TITLE
feat(react): render added HTML files through shared text preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ container before running the e2e tests.
 - **React + TypeScript** (renderer)
 - **shadcn/ui** (UI components, built on Radix primitives)
 - **Prism.js** (syntax highlighting)
-- **react-markdown** + **remark-gfm** (rendered markdown view with AST positions)
+- **react-markdown** + **remark-gfm** (rendered Markdown view with AST positions)
 - **mermaid** (Mermaid diagram rendering)
-- **@tailwindcss/typography** (prose styling for rendered markdown)
+- **@tailwindcss/typography** (prose styling for rendered text content)
 - **Node.js** (main process: CLI, git, IPC, file I/O)
 - **Electron Forge** (build/packaging)
 
@@ -75,7 +75,7 @@ self-review/
 │           │   ├── UnifiedView.tsx    # Single-column unified diff rendering
 │           │   ├── HunkHeader.tsx     # @@ separator rendering
 │           │   ├── ExpandContextBar.tsx # Expand context buttons between hunks
-│           │   ├── RenderedMarkdownView.tsx # Rendered markdown with source-line-mapped gutter
+│           │   ├── RenderedMarkdownView.tsx # Rendered Markdown/HTML with source-line-mapped gutter
 │           │   ├── RenderedImageView.tsx # Rendered preview for raster images (JPG, PNG, GIF, WebP, ICO, BMP)
 │           │   ├── RenderedSvgView.tsx  # Rendered SVG preview via secure img+data-URI
 │           │   └── SyntaxLine.tsx     # Single line with Prism highlighting
@@ -127,19 +127,24 @@ payload. The renderer lazily requests each file's hunks via the `diff:load-file`
 the user navigates, avoiding memory pressure from loading the entire diff at once.
 
 **Rendered previews:** Newly added files (`changeType === 'added'`) of certain types support a
-Raw/Rendered toggle in the file header, following the same eligibility pattern as Markdown:
+Raw/Rendered toggle in the file header:
 - **Markdown** (`.md`, `.markdown`): rendered via `react-markdown` with line-mapped comment gutter;
   files with YAML front matter (`---` delimited) display the metadata as a styled key-value table
   above the prose content, with arrays as `<ul>` lists and objects as nested tables
+- **HTML** (`.html`, `.htm`): rendered directly through the shared rendered-text path used by
+  Markdown, with a source-line-mapped gutter for line-range comments against new-file lines;
+  raw diff mode remains available, and modified/deleted HTML files are not rendered
 - **Raster images** (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.ico`, `.bmp`): loaded as base64
   data URIs via the `diff:load-image` IPC channel and displayed in a constrained `<img>` tag;
   defaults to Rendered view; files over 10 MB show an error message
 - **SVG** (`.svg`): content extracted from addition lines and rendered via `<img>` with a
   `data:image/svg+xml;base64,...` URI (blocks script execution); defaults to Raw view
 
-File-level comments are available on all preview types. Line-level comments are only available
-in the Raw diff view. Detection utilities (`isPreviewableImage`, `isPreviewableSvg`,
-`getLanguageFromPath`) are intentionally duplicated in both `@self-review/core`
+File-level comments are available on all preview types. Line-level comments are available in the
+Raw diff view, and through the source-line-mapped gutter for Markdown and HTML rendered text views.
+Image and SVG rendered previews support file-level comments only. Detection utilities
+(`getRenderedTextMode`, `isPreviewableImage`, `isPreviewableSvg`, `getLanguageFromPath`) are
+intentionally duplicated in both `@self-review/core`
 (`packages/core/src/file-type-utils.ts`) and `@self-review/react`
 (`packages/react/src/utils/file-type-utils.ts`). See the package AGENTS.md files for rationale.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -43,9 +43,9 @@ A single developer working locally with AI coding agents. They are comfortable w
 | UI components | shadcn/ui | Accessible, composable components built on Radix primitives |
 | Syntax highlighting | Prism.js | Broad language coverage, themeable, lightweight |
 | Backend | Node.js | Electron's main process, handles CLI, git, IPC, file I/O |
-| Markdown rendering | react-markdown + remark-gfm | Rendered markdown view with AST position data for line mapping |
+| Rendered text review | react-markdown + remark-gfm, browser HTML parsing | Rendered Markdown and added HTML views with source-line data for line mapping |
 | Diagram rendering | mermaid | Renders Mermaid code blocks as inline SVG diagrams |
-| Prose styling | @tailwindcss/typography | Typography classes for rendered markdown content |
+| Prose styling | @tailwindcss/typography | Typography classes for rendered text content |
 | Build system | Electron Forge or electron-builder | Packaging for macOS and Linux |
 
 ### 2.1 Platform Support
@@ -290,7 +290,7 @@ The selected view mode persists for the session and can be set as a default in c
 
 **Added/deleted file override:** Files with change type `added` or `deleted` always render in unified view, regardless of the selected view mode. In split view, these files would waste half the screen — an added file shows content only on the right pane with the left pane empty, and a deleted file shows content only on the left pane with the right pane empty. Forcing unified view for these files uses the full width for the content that matters.
 
-**Rendered markdown view:** New markdown files (`.md`/`.markdown` with change type `added`) show a per-file "Raw / Rendered" toggle in the file header. When toggled to "Rendered", the file content is displayed as formatted HTML using `react-markdown` with a source-line-mapped gutter. Each rendered block (paragraph, heading, list, code block, table, etc.) is annotated with its source line range from the markdown AST, enabling click-to-comment on rendered content. Mermaid code blocks render as inline SVG diagrams. Comments placed in the rendered view use the same `LineRange` contract as the raw diff view, so switching between views preserves comment placement.
+**Rendered text view:** New Markdown files (`.md`/`.markdown` with change type `added`) and new HTML files (`.html`/`.htm` with change type `added`) show a per-file "Raw / Rendered" toggle in the file header. Raw diff mode remains available for these files. In rendered mode, Markdown content is displayed as formatted HTML using `react-markdown`, while HTML content is rendered directly through the same source-line-mapped gutter path. Each rendered block is annotated with its source line range, enabling gutter-based line-range comments mapped to the new-file line numbers. Mermaid code blocks in Markdown render as inline SVG diagrams. Comments placed in the rendered text view use the same `LineRange` contract as the raw diff view, so switching between raw and rendered views preserves comment placement. Modified, deleted, or otherwise non-added HTML files do not use rendered HTML mode and remain in the raw diff flow.
 
 #### 5.3.3 Syntax Highlighting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "fork-ts-checker-webpack-plugin": "^9.1.0",
         "globals": "^15.15.0",
         "husky": "^9.1.7",
-        "jsdom": "^28.0.0",
+        "jsdom": "^26.1.0",
         "node-loader": "^2.1.0",
         "playwright-bdd": "^8.4.2",
         "postcss-loader": "^8.2.0",
@@ -86,13 +86,6 @@
         "typescript-eslint": "^8.55.0",
         "vitest": "^4.0.18"
       }
-    },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@actions/core": {
       "version": "3.0.0",
@@ -164,59 +157,25 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.7.8",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
-      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.5"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -985,9 +944,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -1001,13 +960,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.1.tgz",
-      "integrity": "sha512-bsDKIP6f4ta2DO9t+rAbSSwv4EMESXy5ZIvzQl1afmD6Z1XHkVu9ijcG9QR/qSgQS1dVa+RaQ/MfQ7FIB/Dn1Q==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -1021,17 +980,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -1045,21 +1004,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.1",
-        "@csstools/css-calc": "^3.0.0"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -1073,33 +1032,16 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0"
-    },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -1113,7 +1055,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@cucumber/ci-environment": {
@@ -3039,24 +2981,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.0.tgz",
-      "integrity": "sha512-YiY1OmY6Qhkvmly8vZiD8wZRpW/npGZNg+0Sk8mstxirRHCg6lolHt5tSODCfuNPE/fBsAqRwDJE417x7jDDHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -9547,16 +9471,6 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
-      }
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -11057,20 +10971,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -11098,29 +10998,17 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -11662,55 +11550,54 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/data-urls/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       }
     },
     "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
-      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/dayjs": {
@@ -15385,16 +15272,16 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.6.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/html-entities": {
@@ -16350,35 +16237,35 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
-      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.7.6",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^5.3.7",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.20.0",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -16441,9 +16328,9 @@
       }
     },
     "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16454,41 +16341,62 @@
       }
     },
     "node_modules/jsdom/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       }
     },
     "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
-      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -17895,13 +17803,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -21018,6 +20919,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -23766,6 +23674,13 @@
         "points-on-curve": "^0.2.0",
         "points-on-path": "^0.2.1"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -28255,22 +28170,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.23"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -28349,13 +28264,13 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^7.0.5"
+        "tldts": "^6.1.32"
       },
       "engines": {
         "node": ">=16"
@@ -28712,16 +28627,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -29653,14 +29558,41 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -30103,7 +30035,7 @@
         "@types/prismjs": "^1.26.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "jsdom": "^28.0.0",
+        "jsdom": "^26.1.0",
         "tailwindcss": "^4.0.0",
         "tsup": "^8.0.0",
         "typescript": "~5.9.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "fork-ts-checker-webpack-plugin": "^9.1.0",
     "globals": "^15.15.0",
     "husky": "^9.1.7",
-    "jsdom": "^28.0.0",
+    "jsdom": "^26.1.0",
     "node-loader": "^2.1.0",
     "playwright-bdd": "^8.4.2",
     "postcss-loader": "^8.2.0",

--- a/packages/core/src/file-type-utils.ts
+++ b/packages/core/src/file-type-utils.ts
@@ -7,6 +7,10 @@
  */
 
 const RASTER_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.ico', '.bmp']);
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+const HTML_EXTENSIONS = new Set(['.html', '.htm']);
+
+export type RenderedTextMode = 'markdown' | 'html';
 
 function getExtension(filePath: string): string {
   const lastDot = filePath.lastIndexOf('.');
@@ -22,6 +26,24 @@ export function isPreviewableSvg(filePath: string): boolean {
   return getExtension(filePath) === '.svg';
 }
 
+export function isMarkdownFile(filePath: string): boolean {
+  return MARKDOWN_EXTENSIONS.has(getExtension(filePath));
+}
+
+export function isHtmlFile(filePath: string): boolean {
+  return HTML_EXTENSIONS.has(getExtension(filePath));
+}
+
+export function getRenderedTextMode(filePath: string): RenderedTextMode | null {
+  if (isMarkdownFile(filePath)) return 'markdown';
+  if (isHtmlFile(filePath)) return 'html';
+  return null;
+}
+
+export function isPreviewableRenderedText(filePath: string): boolean {
+  return getRenderedTextMode(filePath) !== null;
+}
+
 export function getLanguageFromPath(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase() || '';
   const langMap: Record<string, string> = {
@@ -33,6 +55,7 @@ export function getLanguageFromPath(filePath: string): string {
     css: 'css',
     json: 'json',
     md: 'markdown',
+    markdown: 'markdown',
     sh: 'bash',
     bash: 'bash',
     yml: 'yaml',
@@ -42,6 +65,7 @@ export function getLanguageFromPath(filePath: string): string {
     rs: 'rust',
     sql: 'sql',
     html: 'markup',
+    htm: 'markup',
     xml: 'markup',
     rb: 'ruby',
     php: 'php',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,4 +65,13 @@ export { createIgnoreFilter } from './ignore-filter';
 export { checkWritability } from './fs-utils';
 
 // File type detection utilities
-export { isPreviewableImage, isPreviewableSvg, getLanguageFromPath } from './file-type-utils';
+export {
+  getLanguageFromPath,
+  getRenderedTextMode,
+  isHtmlFile,
+  isMarkdownFile,
+  isPreviewableImage,
+  isPreviewableRenderedText,
+  isPreviewableSvg,
+} from './file-type-utils';
+export type { RenderedTextMode } from './file-type-utils';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,10 +33,10 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@self-review/types": "*",
     "@base-ui/react": "^1.1.0",
     "@emoji-mart/data": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@self-review/types": "*",
     "@uiw/react-md-editor": "^4.0.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -63,11 +63,11 @@
     "@types/prismjs": "^1.26.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.0.0",
     "tsup": "^8.0.0",
     "typescript": "~5.9.0",
-    "vitest": "^4.0.18",
-    "jsdom": "^28.0.0"
+    "vitest": "^4.0.18"
   },
   "license": "MIT"
 }

--- a/packages/react/src/components/DiffViewer/DiffContentArea.test.tsx
+++ b/packages/react/src/components/DiffViewer/DiffContentArea.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { DiffFile } from '@self-review/types';
+import { DiffContentArea, type DiffContentAreaProps } from './DiffContentArea';
+import type { RenderedTextMode } from '../../utils/file-type-utils';
+
+vi.mock('../../context/ReviewAdapterContext', () => ({
+  useAdapter: () => ({ loadImage: vi.fn() }),
+}));
+
+vi.mock('./RenderedMarkdownView', () => ({
+  default: ({ contentMode }: { contentMode: RenderedTextMode }) => (
+    <div data-testid='rendered-text-view' data-content-mode={contentMode} />
+  ),
+}));
+
+vi.mock('./RenderedImageView', () => ({
+  default: ({ filePath }: { filePath: string }) => (
+    <div data-testid='rendered-image-view' data-file-path={filePath} />
+  ),
+}));
+
+vi.mock('./RenderedSvgView', () => ({
+  default: () => <div data-testid='rendered-svg-view' />,
+}));
+
+vi.mock('./UnifiedView', () => ({
+  default: () => <div data-testid='unified-view' />,
+}));
+
+vi.mock('./SplitView', () => ({
+  default: () => <div data-testid='split-view' />,
+}));
+
+function makeFile(filePath: string, overrides: Partial<DiffFile> = {}): DiffFile {
+  return {
+    oldPath: filePath,
+    newPath: filePath,
+    changeType: 'added',
+    isBinary: false,
+    hunks: [
+      {
+        header: '@@ -0,0 +1,1 @@',
+        oldStart: 0,
+        oldLines: 0,
+        newStart: 1,
+        newLines: 1,
+        lines: [
+          {
+            type: 'addition',
+            oldLineNumber: null,
+            newLineNumber: 1,
+            content: '<p>Hello</p>',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderContentArea(overrides: Partial<DiffContentAreaProps> = {}) {
+  const file = overrides.file ?? makeFile('index.html');
+  const props: DiffContentAreaProps = {
+    file,
+    filePath: file.newPath || file.oldPath,
+    viewMode: 'unified',
+    renderViewMode: 'rendered',
+    isEligibleForRenderedView: true,
+    renderedTextMode: 'html',
+    showImagePreview: false,
+    showSvgPreview: false,
+    contentLoading: false,
+    contentError: false,
+    onRetry: vi.fn(),
+    commentRange: null,
+    dragState: null,
+    onDragStart: vi.fn(),
+    onCancelComment: vi.fn(),
+    onCommentSaved: vi.fn(),
+    onCommentRange: vi.fn(),
+    isExpandable: false,
+    expandLoading: false,
+    totalLines: null,
+    handleExpandContext: vi.fn(),
+    ...overrides,
+  };
+
+  render(<DiffContentArea {...props} />);
+}
+
+describe('DiffContentArea rendered preview dispatch', () => {
+  it('dispatches added HTML files to the rendered text view with html mode', () => {
+    renderContentArea({
+      file: makeFile('index.html'),
+      renderedTextMode: 'html',
+    });
+
+    expect(screen.getByTestId('rendered-text-view').getAttribute('data-content-mode')).toBe('html');
+  });
+
+  it('keeps added Markdown files on the rendered text view with markdown mode', () => {
+    renderContentArea({
+      file: makeFile('README.md', {
+        hunks: [
+          {
+            header: '@@ -0,0 +1,1 @@',
+            oldStart: 0,
+            oldLines: 0,
+            newStart: 1,
+            newLines: 1,
+            lines: [
+              {
+                type: 'addition',
+                oldLineNumber: null,
+                newLineNumber: 1,
+                content: '# Hello',
+              },
+            ],
+          },
+        ],
+      }),
+      renderedTextMode: 'markdown',
+    });
+
+    expect(screen.getByTestId('rendered-text-view').getAttribute('data-content-mode')).toBe('markdown');
+  });
+
+  it('keeps raster image previews on the image branch', () => {
+    renderContentArea({
+      file: makeFile('assets/photo.png', { isBinary: true, hunks: [] }),
+      isEligibleForRenderedView: false,
+      renderedTextMode: null,
+      showImagePreview: true,
+    });
+
+    expect(screen.getByTestId('rendered-image-view').getAttribute('data-file-path')).toBe('assets/photo.png');
+    expect(screen.queryByTestId('rendered-text-view')).toBeNull();
+  });
+
+  it('keeps SVG previews on the SVG branch', () => {
+    renderContentArea({
+      file: makeFile('assets/icon.svg'),
+      isEligibleForRenderedView: false,
+      renderedTextMode: null,
+      showSvgPreview: true,
+    });
+
+    expect(screen.getByTestId('rendered-svg-view')).toBeTruthy();
+    expect(screen.queryByTestId('rendered-text-view')).toBeNull();
+  });
+
+  it('falls back to raw diff rendering when rendered text mode is unavailable', () => {
+    renderContentArea({
+      renderViewMode: 'rendered',
+      isEligibleForRenderedView: false,
+      renderedTextMode: null,
+    });
+
+    expect(screen.getByTestId('unified-view')).toBeTruthy();
+    expect(screen.queryByTestId('rendered-text-view')).toBeNull();
+  });
+});

--- a/packages/react/src/components/DiffViewer/DiffContentArea.tsx
+++ b/packages/react/src/components/DiffViewer/DiffContentArea.tsx
@@ -112,11 +112,11 @@ export function DiffContentArea({
     );
   }
 
-  if (renderViewMode === 'rendered' && isEligibleForRenderedView) {
+  if (renderViewMode === 'rendered' && isEligibleForRenderedView && renderedTextMode !== null) {
     return (
       <RenderedMarkdownView
         file={file}
-        renderedTextMode={renderedTextMode}
+        contentMode={renderedTextMode}
         commentRange={commentRange}
         onCancelComment={onCancelComment}
         onCommentSaved={onCommentSaved}

--- a/packages/react/src/components/DiffViewer/DiffContentArea.tsx
+++ b/packages/react/src/components/DiffViewer/DiffContentArea.tsx
@@ -8,6 +8,7 @@ import RenderedMarkdownView from './RenderedMarkdownView';
 import RenderedImageView from './RenderedImageView';
 import RenderedSvgView from './RenderedSvgView';
 import { useAdapter } from '../../context/ReviewAdapterContext';
+import type { RenderedTextMode } from '../../utils/file-type-utils';
 
 export interface DiffContentAreaProps {
   file: DiffFile;
@@ -15,6 +16,7 @@ export interface DiffContentAreaProps {
   viewMode: 'split' | 'unified';
   renderViewMode: 'raw' | 'rendered';
   isEligibleForRenderedView: boolean;
+  renderedTextMode: RenderedTextMode | null;
   showImagePreview: boolean;
   showSvgPreview: boolean;
   contentLoading: boolean;
@@ -42,6 +44,7 @@ export function DiffContentArea({
   viewMode,
   renderViewMode,
   isEligibleForRenderedView,
+  renderedTextMode,
   showImagePreview,
   showSvgPreview,
   contentLoading,
@@ -113,6 +116,7 @@ export function DiffContentArea({
     return (
       <RenderedMarkdownView
         file={file}
+        renderedTextMode={renderedTextMode}
         commentRange={commentRange}
         onCancelComment={onCancelComment}
         onCommentSaved={onCommentSaved}

--- a/packages/react/src/components/DiffViewer/FileSection.test.tsx
+++ b/packages/react/src/components/DiffViewer/FileSection.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { DiffFile } from '@self-review/types';
+import FileSection from './FileSection';
+import type { FileSectionHeaderProps } from './FileSectionHeader';
+import type { DiffContentAreaProps } from './DiffContentArea';
+
+vi.mock('../../context/ReviewContext', () => ({
+  useReview: () => ({
+    toggleViewed: vi.fn(),
+    getCommentsForFile: vi.fn(() => []),
+    files: [],
+    diffSource: { type: 'git' },
+    updateFileHunks: vi.fn(),
+  }),
+}));
+
+vi.mock('../../context/ReviewAdapterContext', () => ({
+  useAdapter: () => null,
+}));
+
+vi.mock('./useDragSelection', () => ({
+  useDragSelection: () => ({
+    dragState: null,
+    handleDragStart: vi.fn(),
+  }),
+}));
+
+vi.mock('./useExpandContext', () => ({
+  useExpandContext: () => ({
+    expandLoading: false,
+    totalLines: null,
+    handleExpandContext: vi.fn(),
+  }),
+}));
+
+vi.mock('./FileSectionHeader', () => ({
+  FileSectionHeader: ({ isPreviewable, renderViewMode }: FileSectionHeaderProps) => (
+    <div
+      data-testid='mock-file-section-header'
+      data-previewable={String(isPreviewable)}
+      data-render-view-mode={renderViewMode}
+    />
+  ),
+}));
+
+vi.mock('./FileSectionBody', () => ({
+  FileSectionBody: ({ contentAreaProps }: { contentAreaProps: DiffContentAreaProps }) => (
+    <div
+      data-testid='mock-file-section-body'
+      data-render-view-mode={contentAreaProps.renderViewMode}
+      data-rendered-text-mode={contentAreaProps.renderedTextMode ?? 'null'}
+      data-eligible-rendered-text={String(contentAreaProps.isEligibleForRenderedView)}
+      data-show-image-preview={String(contentAreaProps.showImagePreview)}
+      data-show-svg-preview={String(contentAreaProps.showSvgPreview)}
+    />
+  ),
+}));
+
+function makeDiffFile(
+  filePath: string,
+  overrides: Partial<DiffFile> = {},
+): DiffFile {
+  return {
+    oldPath: filePath,
+    newPath: filePath,
+    changeType: 'added',
+    isBinary: false,
+    hunks: [],
+    ...overrides,
+  };
+}
+
+function renderFileSection(file: DiffFile) {
+  render(<FileSection file={file} viewMode='unified' expanded={true} />);
+  return {
+    header: screen.getByTestId('mock-file-section-header'),
+    body: screen.getByTestId('mock-file-section-body'),
+  };
+}
+
+describe('FileSection preview eligibility', () => {
+  it('marks added HTML files as rendered-text previewable', () => {
+    const { header, body } = renderFileSection(makeDiffFile('index.html'));
+
+    expect(header.getAttribute('data-previewable')).toBe('true');
+    expect(header.getAttribute('data-render-view-mode')).toBe('rendered');
+    expect(body.getAttribute('data-eligible-rendered-text')).toBe('true');
+    expect(body.getAttribute('data-rendered-text-mode')).toBe('html');
+  });
+
+  it('marks added HTM files as rendered-text previewable', () => {
+    const { body } = renderFileSection(makeDiffFile('templates/page.htm'));
+
+    expect(body.getAttribute('data-eligible-rendered-text')).toBe('true');
+    expect(body.getAttribute('data-rendered-text-mode')).toBe('html');
+  });
+
+  it('keeps added Markdown files on the rendered-text path', () => {
+    const { header, body } = renderFileSection(makeDiffFile('README.markdown'));
+
+    expect(header.getAttribute('data-previewable')).toBe('true');
+    expect(body.getAttribute('data-eligible-rendered-text')).toBe('true');
+    expect(body.getAttribute('data-rendered-text-mode')).toBe('markdown');
+  });
+
+  it('does not make non-added HTML files previewable', () => {
+    const { header, body } = renderFileSection(
+      makeDiffFile('index.html', { changeType: 'modified' }),
+    );
+
+    expect(header.getAttribute('data-previewable')).toBe('false');
+    expect(header.getAttribute('data-render-view-mode')).toBe('raw');
+    expect(body.getAttribute('data-eligible-rendered-text')).toBe('false');
+    expect(body.getAttribute('data-rendered-text-mode')).toBe('null');
+  });
+
+  it('preserves image and SVG preview flags without rendered-text mode', () => {
+    const image = renderFileSection(makeDiffFile('photo.png', { isBinary: true }));
+    expect(image.body.getAttribute('data-show-image-preview')).toBe('true');
+    expect(image.body.getAttribute('data-show-svg-preview')).toBe('false');
+    expect(image.body.getAttribute('data-rendered-text-mode')).toBe('null');
+
+    cleanup();
+
+    const svg = renderFileSection(makeDiffFile('icon.svg'));
+    expect(svg.body.getAttribute('data-show-image-preview')).toBe('false');
+    expect(svg.body.getAttribute('data-show-svg-preview')).toBe('true');
+    expect(svg.body.getAttribute('data-rendered-text-mode')).toBe('null');
+  });
+});

--- a/packages/react/src/components/DiffViewer/FileSection.test.tsx
+++ b/packages/react/src/components/DiffViewer/FileSection.test.tsx
@@ -118,6 +118,9 @@ describe('FileSection preview eligibility', () => {
 
   it('preserves image and SVG preview flags without rendered-text mode', () => {
     const image = renderFileSection(makeDiffFile('photo.png', { isBinary: true }));
+    expect(image.header.getAttribute('data-previewable')).toBe('true');
+    expect(image.header.getAttribute('data-render-view-mode')).toBe('rendered');
+    expect(image.body.getAttribute('data-render-view-mode')).toBe('rendered');
     expect(image.body.getAttribute('data-show-image-preview')).toBe('true');
     expect(image.body.getAttribute('data-show-svg-preview')).toBe('false');
     expect(image.body.getAttribute('data-rendered-text-mode')).toBe('null');
@@ -125,6 +128,9 @@ describe('FileSection preview eligibility', () => {
     cleanup();
 
     const svg = renderFileSection(makeDiffFile('icon.svg'));
+    expect(svg.header.getAttribute('data-previewable')).toBe('true');
+    expect(svg.header.getAttribute('data-render-view-mode')).toBe('raw');
+    expect(svg.body.getAttribute('data-render-view-mode')).toBe('raw');
     expect(svg.body.getAttribute('data-show-image-preview')).toBe('false');
     expect(svg.body.getAttribute('data-show-svg-preview')).toBe('true');
     expect(svg.body.getAttribute('data-rendered-text-mode')).toBe('null');

--- a/packages/react/src/components/DiffViewer/FileSection.tsx
+++ b/packages/react/src/components/DiffViewer/FileSection.tsx
@@ -4,7 +4,7 @@ import { useExpandContext } from './useExpandContext';
 import type { DiffFile } from '@self-review/types';
 import { useReview } from '../../context/ReviewContext';
 import { useAdapter } from '../../context/ReviewAdapterContext';
-import { isPreviewableImage, isPreviewableSvg } from '../../utils/file-type-utils';
+import { getRenderedTextMode, isPreviewableImage, isPreviewableSvg } from '../../utils/file-type-utils';
 import { FileSectionHeader } from './FileSectionHeader';
 import { FileSectionBody } from './FileSectionBody';
 
@@ -38,7 +38,8 @@ export default function FileSection({
   const filePath_ = file.newPath || file.oldPath || '';
   const showImagePreview = isAddedFile && file.isBinary === true && isPreviewableImage(filePath_);
   const showSvgPreview = isAddedFile && isPreviewableSvg(filePath_);
-  const isEligibleForRenderedView = isAddedFile && /\.(md|markdown)$/i.test(filePath_);
+  const renderedTextMode = isAddedFile ? getRenderedTextMode(filePath_) : null;
+  const isEligibleForRenderedView = renderedTextMode !== null;
   const isPreviewable = showImagePreview || showSvgPreview || isEligibleForRenderedView;
 
   const initialViewMode = isPreviewable ? 'rendered' : 'raw';
@@ -162,6 +163,7 @@ export default function FileSection({
             viewMode: effectiveViewMode,
             renderViewMode,
             isEligibleForRenderedView,
+            renderedTextMode,
             showImagePreview,
             showSvgPreview,
             contentLoading,

--- a/packages/react/src/components/DiffViewer/FileSection.tsx
+++ b/packages/react/src/components/DiffViewer/FileSection.tsx
@@ -42,7 +42,7 @@ export default function FileSection({
   const isEligibleForRenderedView = renderedTextMode !== null;
   const isPreviewable = showImagePreview || showSvgPreview || isEligibleForRenderedView;
 
-  const initialViewMode = isPreviewable ? 'rendered' : 'raw';
+  const initialViewMode = showSvgPreview ? 'raw' : isPreviewable ? 'rendered' : 'raw';
   const [renderViewMode, setRenderViewMode] = useState<'raw' | 'rendered'>(initialViewMode);
 
   const filePath = file.newPath || file.oldPath;

--- a/packages/react/src/components/DiffViewer/RenderedMarkdownView.test.tsx
+++ b/packages/react/src/components/DiffViewer/RenderedMarkdownView.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { DiffFile, ReviewComment } from '@self-review/types';
+import RenderedMarkdownView from './RenderedMarkdownView';
+import type { RenderedTextMode } from '../../utils/file-type-utils';
+
+const mockState = vi.hoisted(() => ({
+  comments: [] as ReviewComment[],
+}));
+
+vi.mock('../../context/ReviewContext', () => ({
+  useReview: () => ({
+    getCommentsForFile: vi.fn(() => mockState.comments),
+  }),
+}));
+
+vi.mock('../Comments/CommentInput', () => ({
+  default: () => <div data-testid='comment-input' />,
+}));
+
+vi.mock('../Comments/CommentDisplay', () => ({
+  default: ({ comment }: { comment: ReviewComment }) => (
+    <div data-testid='comment-display'>{comment.body}</div>
+  ),
+}));
+
+vi.mock('./MermaidBlock', () => ({
+  default: ({ code }: { code: string }) => <pre data-testid='mermaid-block'>{code}</pre>,
+}));
+
+function makeAddedFile(filePath: string, lines: string[]): DiffFile {
+  return {
+    oldPath: filePath,
+    newPath: filePath,
+    changeType: 'added',
+    isBinary: false,
+    hunks: [
+      {
+        header: `@@ -0,0 +1,${lines.length} @@`,
+        oldStart: 0,
+        oldLines: 0,
+        newStart: 1,
+        newLines: lines.length,
+        lines: lines.map((content, index) => ({
+          type: 'addition',
+          oldLineNumber: null,
+          newLineNumber: index + 1,
+          content,
+        })),
+      },
+    ],
+  };
+}
+
+function renderView(
+  file: DiffFile,
+  contentMode: RenderedTextMode,
+  onGutterMouseDown = vi.fn(),
+) {
+  const result = render(
+    <RenderedMarkdownView
+      file={file}
+      contentMode={contentMode}
+      commentRange={null}
+      onCancelComment={vi.fn()}
+      onCommentSaved={vi.fn()}
+      onGutterMouseDown={onGutterMouseDown}
+    />,
+  );
+
+  return { ...result, onGutterMouseDown };
+}
+
+describe('RenderedMarkdownView', () => {
+  beforeEach(() => {
+    mockState.comments = [];
+  });
+
+  it('keeps Markdown front matter, emoji, and source-line mapping', () => {
+    const file = makeAddedFile('README.md', [
+      '---',
+      'title: Guide',
+      '---',
+      '# Hello :rocket:',
+      '',
+      '- item',
+    ]);
+
+    const { container } = renderView(file, 'markdown');
+
+    expect(container.firstElementChild?.getAttribute('data-rendered-text-mode')).toBe('markdown');
+    expect(screen.getByText('title')).toBeTruthy();
+    expect(screen.getByText('Guide')).toBeTruthy();
+    expect(screen.getByText('Hello 🚀').closest('h1')?.getAttribute('data-source-start-line')).toBe('4');
+  });
+
+  it('renders added-file HTML directly through commentable block wrappers', () => {
+    const file = makeAddedFile('index.html', [
+      '<section>',
+      '  <h1>Hello <span>HTML</span></h1>',
+      '  <p>First block</p>',
+      '  <p>Second block</p>',
+      '</section>',
+    ]);
+
+    const { container, onGutterMouseDown } = renderView(file, 'html');
+    const firstParagraph = screen.getByText('First block').closest('p');
+
+    expect(container.firstElementChild?.getAttribute('data-rendered-text-mode')).toBe('html');
+    expect(container.querySelector('h1')?.getAttribute('data-source-start-line')).toBe('2');
+    expect(firstParagraph?.getAttribute('data-source-start-line')).toBe('3');
+
+    const gutterButton = firstParagraph?.querySelector('button');
+    expect(gutterButton).not.toBeNull();
+    fireEvent.mouseDown(gutterButton as HTMLButtonElement);
+
+    expect(onGutterMouseDown).toHaveBeenCalledWith(3, 3);
+  });
+
+  it('displays existing line comments on rendered HTML blocks', () => {
+    mockState.comments = [
+      {
+        id: 'comment-1',
+        filePath: 'index.html',
+        lineRange: { side: 'new', start: 3, end: 3 },
+        body: 'Comment for first paragraph',
+        category: 'note',
+        suggestion: null,
+      },
+    ];
+
+    const file = makeAddedFile('index.html', [
+      '<main>',
+      '  <h1>Hello</h1>',
+      '  <p>First block</p>',
+      '</main>',
+    ]);
+
+    renderView(file, 'html');
+
+    expect(screen.getByTestId('comment-display').textContent).toBe('Comment for first paragraph');
+  });
+
+  it('omits HTML that can execute scripts or load external resources', () => {
+    const file = makeAddedFile('index.html', [
+      '<h1 onclick="alert(1)">Safe heading</h1>',
+      '<img src="https://example.com/image.png" alt="External image">',
+      '<iframe src="https://example.com"></iframe>',
+      '<script>alert(1)</script>',
+    ]);
+
+    const { container } = renderView(file, 'html');
+
+    expect(screen.getByText('Safe heading')).toBeTruthy();
+    expect(container.querySelector('h1')?.getAttribute('onclick')).toBeNull();
+    expect(container.querySelector('img')?.getAttribute('src')).toBeNull();
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.querySelector('script')).toBeNull();
+  });
+});

--- a/packages/react/src/components/DiffViewer/RenderedMarkdownView.tsx
+++ b/packages/react/src/components/DiffViewer/RenderedMarkdownView.tsx
@@ -24,12 +24,30 @@ const GutterNestingContext = createContext(false);
 
 // ===== Content Extraction =====
 
-function extractFileContent(file: DiffFile): string {
-  return file.hunks
-    .flatMap(hunk => hunk.lines)
-    .filter(line => line.type === 'addition')
-    .map(line => line.content)
-    .join('\n');
+interface AddedFileLine {
+  lineNumber: number;
+  content: string;
+}
+
+function extractAddedFileLines(file: DiffFile): AddedFileLine[] {
+  const lines: AddedFileLine[] = [];
+  let fallbackLineNumber = 1;
+
+  for (const hunk of file.hunks) {
+    for (const line of hunk.lines) {
+      if (line.type !== 'addition') continue;
+
+      const lineNumber = line.newLineNumber ?? fallbackLineNumber;
+      lines.push({ lineNumber, content: line.content });
+      fallbackLineNumber = lineNumber + 1;
+    }
+  }
+
+  return lines;
+}
+
+function extractFileContent(lines: AddedFileLine[]): string {
+  return lines.map(line => line.content).join('\n');
 }
 
 // Tags that accept phrasing (inline) content — the Tag itself can be the
@@ -39,6 +57,115 @@ function extractFileContent(file: DiffFile): string {
 const INLINE_SAFE_TAGS: ReadonlySet<string> = new Set([
   'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'li', 'details',
 ]);
+
+const HTML_VOID_TAGS: ReadonlySet<string> = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta',
+  'param', 'source', 'track', 'wbr',
+]);
+
+const HTML_BLOCK_TAGS: ReadonlySet<string> = new Set([
+  'address', 'article', 'aside', 'blockquote', 'details', 'dialog', 'div', 'dl',
+  'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4',
+  'h5', 'h6', 'header', 'hr', 'li', 'main', 'nav', 'ol', 'p', 'pre', 'section',
+  'table', 'ul',
+]);
+
+const HTML_CONTAINER_TAGS: ReadonlySet<string> = new Set([
+  'article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section',
+]);
+
+const HTML_SKIPPED_TAGS: ReadonlySet<string> = new Set([
+  'base', 'embed', 'iframe', 'link', 'meta', 'object', 'script', 'style',
+]);
+
+const HTML_SKIPPED_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'href', 'src', 'srcdoc', 'srcset', 'style',
+]);
+
+interface HtmlToken {
+  tagName: string;
+  line: number;
+  kind: 'open' | 'close';
+  selfClosing: boolean;
+}
+
+interface HtmlLinePosition {
+  startLine: number | undefined;
+  endLine: number | undefined;
+}
+
+function getLineNumberAtIndex(content: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i++) {
+    if (content[i] === '\n') line++;
+  }
+  return line;
+}
+
+function getAddedLineNumber(contentLineNumber: number, lines: AddedFileLine[]): number {
+  return lines[contentLineNumber - 1]?.lineNumber ?? contentLineNumber;
+}
+
+function tokenizeHtml(content: string, lines: AddedFileLine[]): HtmlToken[] {
+  const tokens: HtmlToken[] = [];
+  const tagPattern = /<\s*(\/)?\s*([a-zA-Z][\w:-]*)([\s\S]*?)>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagPattern.exec(content)) !== null) {
+    const [, closingSlash, rawTagName, rawRest] = match;
+    const tagName = rawTagName.toLowerCase();
+    const kind = closingSlash ? 'close' : 'open';
+    tokens.push({
+      tagName,
+      line: getAddedLineNumber(getLineNumberAtIndex(content, match.index), lines),
+      kind,
+      selfClosing: kind === 'open' && (HTML_VOID_TAGS.has(tagName) || /\/\s*$/.test(rawRest)),
+    });
+  }
+
+  return tokens;
+}
+
+function createHtmlLineResolver(content: string, lines: AddedFileLine[]) {
+  const tokens = tokenizeHtml(content, lines);
+  let tokenCursor = 0;
+
+  return (tagName: string): HtmlLinePosition => {
+    const normalizedTagName = tagName.toLowerCase();
+    const startTokenIndex = tokens.findIndex((token, index) =>
+      index >= tokenCursor &&
+      token.kind === 'open' &&
+      token.tagName === normalizedTagName
+    );
+
+    if (startTokenIndex === -1) {
+      return { startLine: undefined, endLine: undefined };
+    }
+
+    tokenCursor = startTokenIndex + 1;
+    const startToken = tokens[startTokenIndex];
+    let endLine = startToken.line;
+
+    if (!startToken.selfClosing) {
+      let depth = 0;
+      for (let i = startTokenIndex; i < tokens.length; i++) {
+        const token = tokens[i];
+        if (token.tagName !== normalizedTagName) continue;
+        if (token.kind === 'open' && !token.selfClosing) {
+          depth++;
+        } else if (token.kind === 'close') {
+          depth--;
+          if (depth === 0) {
+            endLine = token.line;
+            break;
+          }
+        }
+      }
+    }
+
+    return { startLine: startToken.line, endLine };
+  };
+}
 
 // ===== Block Wrapper with Gutter =====
 
@@ -95,7 +222,7 @@ function BlockWrapper({
     commentRange.end <= endLine;
 
   // Void elements (hr, img, etc.) can't have children
-  const isVoid = Tag === 'hr';
+  const isVoid = HTML_VOID_TAGS.has(Tag as string);
 
   // Tags that accept phrasing (inline) content as children — the Tag itself
   // becomes the positioned container so that selectors like `p.rendered-block`
@@ -203,23 +330,141 @@ function BlockWrapper({
 
 export interface RenderedMarkdownViewProps {
   file: DiffFile;
-  renderedTextMode?: RenderedTextMode | null;
+  contentMode: RenderedTextMode;
   commentRange: { start: number; end: number; side: 'old' | 'new' } | null;
   onCancelComment: () => void;
   onCommentSaved: () => void;
   onGutterMouseDown: (startLine: number, endLine: number) => void;
 }
 
+interface HtmlRenderedContentProps {
+  content: string;
+  lines: AddedFileLine[];
+  file: DiffFile;
+  filePath: string;
+  lineRange: LineRange | null;
+  onGutterMouseDown: (startLine: number, endLine: number) => void;
+  onCancelComment: () => void;
+  onCommentSaved: () => void;
+}
+
+function getHtmlAttributeProps(element: Element): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+
+  for (const attribute of Array.from(element.attributes)) {
+    const attributeName = attribute.name.toLowerCase();
+    if (attributeName.startsWith('on') || HTML_SKIPPED_ATTRIBUTES.has(attributeName)) continue;
+    if (attributeName === 'class') {
+      props.className = attribute.value;
+    } else if (attributeName === 'for') {
+      props.htmlFor = attribute.value;
+    } else {
+      props[attribute.name] = attribute.value;
+    }
+  }
+
+  return props;
+}
+
+function hasBlockElementChild(element: Element): boolean {
+  return Array.from(element.children).some(child =>
+    HTML_BLOCK_TAGS.has(child.tagName.toLowerCase())
+  );
+}
+
+function shouldWrapHtmlElement(element: Element): boolean {
+  const tagName = element.tagName.toLowerCase();
+  if (!HTML_BLOCK_TAGS.has(tagName)) return false;
+  if (HTML_CONTAINER_TAGS.has(tagName) && hasBlockElementChild(element)) return false;
+  return true;
+}
+
+function HtmlRenderedContent({
+  content,
+  lines,
+  file,
+  filePath,
+  lineRange,
+  onGutterMouseDown,
+  onCancelComment,
+  onCommentSaved,
+}: HtmlRenderedContentProps) {
+  const lineResolver = createHtmlLineResolver(content, lines);
+  const document = useMemo(() => {
+    const parser = new DOMParser();
+    return parser.parseFromString(content, 'text/html');
+  }, [content]);
+
+  const renderNode = useCallback((
+    node: Node,
+    key: React.Key,
+    insideWrappedBlock = false
+  ): React.ReactNode => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent;
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return null;
+    }
+
+    const element = node as Element;
+    const tagName = element.tagName.toLowerCase() as keyof React.JSX.IntrinsicElements;
+    if (HTML_SKIPPED_TAGS.has(tagName)) {
+      return null;
+    }
+
+    const tagProps = getHtmlAttributeProps(element);
+    const shouldWrap = !insideWrappedBlock && shouldWrapHtmlElement(element);
+    const children = Array.from(element.childNodes).map((child, index) =>
+      renderNode(child, index, insideWrappedBlock || shouldWrap)
+    );
+
+    if (shouldWrap) {
+      const { startLine, endLine } = lineResolver(tagName);
+      return (
+        <BlockWrapper
+          key={key}
+          startLine={startLine}
+          endLine={endLine}
+          tag={tagName}
+          filePath={filePath}
+          file={file}
+          commentRange={lineRange}
+          onGutterMouseDown={onGutterMouseDown}
+          onCancelComment={onCancelComment}
+          onCommentSaved={onCommentSaved}
+          tagProps={tagProps}
+        >
+          {children}
+        </BlockWrapper>
+      );
+    }
+
+    return React.createElement(
+      tagName,
+      { key, ...tagProps },
+      HTML_VOID_TAGS.has(tagName) ? undefined : children
+    );
+  }, [file, filePath, lineRange, lineResolver, onCancelComment, onCommentSaved, onGutterMouseDown]);
+
+  return <>{Array.from(document.body.childNodes).map((node, index) => renderNode(node, index))}</>;
+}
+
 export default function RenderedMarkdownView({
   file,
-  renderedTextMode = 'markdown',
+  contentMode,
   commentRange,
   onCancelComment,
   onCommentSaved,
   onGutterMouseDown,
 }: RenderedMarkdownViewProps) {
-  const content = useMemo(() => extractFileContent(file), [file]);
-  const frontMatter = useMemo(() => parseFrontMatter(content), [content]);
+  const addedLines = useMemo(() => extractAddedFileLines(file), [file]);
+  const content = useMemo(() => extractFileContent(addedLines), [addedLines]);
+  const frontMatter = useMemo(
+    () => contentMode === 'markdown' ? parseFrontMatter(content) : null,
+    [content, contentMode]
+  );
   const markdownBody = frontMatter ? frontMatter.body : content;
   const lineOffset = frontMatter ? frontMatter.lineOffset : 0;
   const filePath = file.newPath || file.oldPath;
@@ -306,16 +551,29 @@ export default function RenderedMarkdownView({
   return (
     <div
       className='prose dark:prose-invert max-w-none p-4 rendered-markdown-view'
-      data-rendered-text-mode={renderedTextMode}
+      data-rendered-text-mode={contentMode}
     >
       {frontMatter && <FrontMatterTable metadata={frontMatter.metadata} />}
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkEmoji]}
-        rehypePlugins={[rehypeRaw]}
-        components={components}
-      >
-        {markdownBody}
-      </ReactMarkdown>
+      {contentMode === 'markdown' ? (
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm, remarkEmoji]}
+          rehypePlugins={[rehypeRaw]}
+          components={components}
+        >
+          {markdownBody}
+        </ReactMarkdown>
+      ) : (
+        <HtmlRenderedContent
+          content={content}
+          lines={addedLines}
+          file={file}
+          filePath={filePath}
+          lineRange={lineRange}
+          onGutterMouseDown={onGutterMouseDown}
+          onCancelComment={onCancelComment}
+          onCommentSaved={onCommentSaved}
+        />
+      )}
     </div>
   );
 }

--- a/packages/react/src/components/DiffViewer/RenderedMarkdownView.tsx
+++ b/packages/react/src/components/DiffViewer/RenderedMarkdownView.tsx
@@ -14,6 +14,7 @@ import MermaidBlock from './MermaidBlock';
 import { remarkEmoji } from '../../utils/remark-emoji';
 import { parseFrontMatter } from '../../utils/front-matter';
 import FrontMatterTable from './FrontMatterTable';
+import type { RenderedTextMode } from '../../utils/file-type-utils';
 
 // ===== Nesting Context =====
 // Tracks whether we're inside a block that already has a gutter wrapper,
@@ -202,6 +203,7 @@ function BlockWrapper({
 
 export interface RenderedMarkdownViewProps {
   file: DiffFile;
+  renderedTextMode?: RenderedTextMode | null;
   commentRange: { start: number; end: number; side: 'old' | 'new' } | null;
   onCancelComment: () => void;
   onCommentSaved: () => void;
@@ -210,6 +212,7 @@ export interface RenderedMarkdownViewProps {
 
 export default function RenderedMarkdownView({
   file,
+  renderedTextMode = 'markdown',
   commentRange,
   onCancelComment,
   onCommentSaved,
@@ -301,7 +304,10 @@ export default function RenderedMarkdownView({
   }), [createBlockRenderer, CodeRenderer]);
 
   return (
-    <div className='prose dark:prose-invert max-w-none p-4 rendered-markdown-view'>
+    <div
+      className='prose dark:prose-invert max-w-none p-4 rendered-markdown-view'
+      data-rendered-text-mode={renderedTextMode}
+    >
       {frontMatter && <FrontMatterTable metadata={frontMatter.metadata} />}
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkEmoji]}

--- a/packages/react/src/file-type-utils.test.ts
+++ b/packages/react/src/file-type-utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { isPreviewableImage, isPreviewableSvg } from './utils/file-type-utils';
+import {
+  getRenderedTextMode,
+  isHtmlFile,
+  isMarkdownFile,
+  isPreviewableImage,
+  isPreviewableRenderedText,
+  isPreviewableSvg,
+} from './utils/file-type-utils';
 
 describe('isPreviewableImage', () => {
   it('returns true for .jpg', () => {
@@ -74,5 +81,27 @@ describe('isPreviewableSvg', () => {
 
   it('works with paths containing directories', () => {
     expect(isPreviewableSvg('assets/icons/logo.svg')).toBe(true);
+  });
+});
+
+describe('rendered text helpers', () => {
+  it('recognizes markdown files as rendered text', () => {
+    expect(isMarkdownFile('README.md')).toBe(true);
+    expect(isMarkdownFile('docs/guide.markdown')).toBe(true);
+    expect(isPreviewableRenderedText('README.MD')).toBe(true);
+    expect(getRenderedTextMode('docs/guide.markdown')).toBe('markdown');
+  });
+
+  it('recognizes .html and .htm files as rendered text', () => {
+    expect(isHtmlFile('page.html')).toBe(true);
+    expect(isHtmlFile('templates/index.htm')).toBe(true);
+    expect(isPreviewableRenderedText('PAGE.HTML')).toBe(true);
+    expect(getRenderedTextMode('templates/index.htm')).toBe('html');
+  });
+
+  it('does not classify images, svg, or extensionless files as rendered text', () => {
+    expect(getRenderedTextMode('image.png')).toBeNull();
+    expect(getRenderedTextMode('icon.svg')).toBeNull();
+    expect(getRenderedTextMode('Dockerfile')).toBeNull();
   });
 });

--- a/packages/react/src/utils/file-type-utils.ts
+++ b/packages/react/src/utils/file-type-utils.ts
@@ -11,6 +11,10 @@
  */
 
 const RASTER_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.ico', '.bmp']);
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+const HTML_EXTENSIONS = new Set(['.html', '.htm']);
+
+export type RenderedTextMode = 'markdown' | 'html';
 
 function getExtension(filePath: string): string {
   const lastDot = filePath.lastIndexOf('.');
@@ -26,6 +30,24 @@ export function isPreviewableSvg(filePath: string): boolean {
   return getExtension(filePath) === '.svg';
 }
 
+export function isMarkdownFile(filePath: string): boolean {
+  return MARKDOWN_EXTENSIONS.has(getExtension(filePath));
+}
+
+export function isHtmlFile(filePath: string): boolean {
+  return HTML_EXTENSIONS.has(getExtension(filePath));
+}
+
+export function getRenderedTextMode(filePath: string): RenderedTextMode | null {
+  if (isMarkdownFile(filePath)) return 'markdown';
+  if (isHtmlFile(filePath)) return 'html';
+  return null;
+}
+
+export function isPreviewableRenderedText(filePath: string): boolean {
+  return getRenderedTextMode(filePath) !== null;
+}
+
 export function getLanguageFromPath(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase() || '';
   const langMap: Record<string, string> = {
@@ -37,6 +59,7 @@ export function getLanguageFromPath(filePath: string): string {
     css: 'css',
     json: 'json',
     md: 'markdown',
+    markdown: 'markdown',
     sh: 'bash',
     bash: 'bash',
     yml: 'yaml',
@@ -46,6 +69,7 @@ export function getLanguageFromPath(filePath: string): string {
     rs: 'rust',
     sql: 'sql',
     html: 'markup',
+    htm: 'markup',
     xml: 'markup',
     rb: 'ruby',
     php: 'php',

--- a/tests/webapp-features/09-rendered-html.feature
+++ b/tests/webapp-features/09-rendered-html.feature
@@ -1,0 +1,29 @@
+Feature: Rendered HTML View
+  As a developer using the @self-review/react library
+  I want to review new HTML files in rendered format
+  So that rendered HTML supports the same comment workflow as rendered Markdown
+
+  Background:
+    Given the webapp is loaded with rendered HTML fixture data
+
+  Scenario: Added HTML file shows rendered content with commentable gutters
+    Then I should see a "Rendered" toggle in the file header for "docs/page.html"
+    When I click the "Rendered" toggle for "docs/page.html"
+    Then I should see the HTML rendered as formatted content
+    And the gutter should show collapsed line ranges like "7-10"
+
+  Scenario: Rendered HTML comments save expected new-line ranges
+    When I click the "Rendered" toggle for "docs/page.html"
+    And I add rendered comment "Review intro copy" on the block containing "Intro paragraph for rendered review."
+    And I add rendered comment "Review list grouping" on the block containing "First listed item"
+    And I finish the webapp review
+    Then the saved review should include comments for "docs/page.html":
+      | body                 | side | start | end |
+      | Review intro copy    | new  | 3     | 3   |
+      | Review list grouping | new  | 7     | 10  |
+
+  Scenario: Rendered Markdown commenting still uses the shared workflow
+    When I click the "Rendered" toggle for "docs/new-docs.md"
+    And I add a comment on the paragraph block
+    And I click the "Raw" toggle for "docs/new-docs.md"
+    Then the comment should appear at the same source lines in the raw view

--- a/tests/webapp-steps/08-rendered-markdown.steps.ts
+++ b/tests/webapp-steps/08-rendered-markdown.steps.ts
@@ -3,8 +3,9 @@
  * Adapted from Electron steps — uses the webapp launcher with markdown fixture.
  */
 import { expect } from '@playwright/test';
-import { createBdd } from 'playwright-bdd';
+import { createBdd, DataTable } from 'playwright-bdd';
 import { launchWebapp, cleanup, getPage } from './app';
+import type { ReviewState } from '../../packages/core/src/types';
 
 const { Given, When, Then, After } = createBdd();
 
@@ -16,6 +17,10 @@ After(async () => {
 
 Given('the webapp is loaded with markdown fixture data', async () => {
   await launchWebapp({ fixture: 'markdown' });
+});
+
+Given('the webapp is loaded with rendered HTML fixture data', async () => {
+  await launchWebapp({ fixture: 'rendered-html' });
 });
 
 // ── When steps ──
@@ -51,6 +56,28 @@ When('I add a comment on the paragraph block', async () => {
   await page.locator('[data-testid="add-comment-btn"]').click();
 });
 
+When(
+  'I add rendered comment {string} on the block containing {string}',
+  async ({}, commentBody: string, blockText: string) => {
+    const page = getPage();
+    const block = page.locator('.rendered-block').filter({ hasText: blockText }).first();
+    await block.waitFor({ state: 'visible', timeout: 5000 });
+    await block.hover();
+    await block.locator('.rendered-gutter').dispatchEvent('mousedown');
+    const input = page.locator('[data-testid="comment-input"]');
+    await input.waitFor({ state: 'visible', timeout: 5000 });
+    await input.locator('textarea').fill(commentBody);
+    await page.locator('[data-testid="add-comment-btn"]').click();
+    await expect(input).toHaveCount(0, { timeout: 5000 });
+  }
+);
+
+When('I finish the webapp review', async () => {
+  const page = getPage();
+  await page.locator('[data-testid="finish-review-btn"]').click();
+  await page.locator('#review-state').waitFor({ state: 'attached', timeout: 5000 });
+});
+
 // ── Then steps ──
 
 Then(
@@ -77,6 +104,17 @@ Then('I should see the markdown rendered as formatted HTML', async () => {
   await expect(view).toBeVisible({ timeout: 5000 });
   const hasContent = await view.locator('h1, h2, h3, p, ul, ol, pre').count();
   expect(hasContent).toBeGreaterThan(0);
+});
+
+Then('I should see the HTML rendered as formatted content', async () => {
+  const page = getPage();
+  const view = page.locator('.rendered-markdown-view[data-rendered-text-mode="html"]');
+  await expect(view).toBeVisible({ timeout: 5000 });
+  await expect(view.locator('h1')).toContainText('Release Notes');
+  await expect(
+    view.locator('p').filter({ hasText: 'Intro paragraph for rendered review.' }).first()
+  ).toBeVisible();
+  await expect(view.locator('ul').filter({ hasText: 'First listed item' }).first()).toBeVisible();
 });
 
 Then('I should see a gutter with line ranges', async () => {
@@ -125,3 +163,25 @@ Then('the mermaid code block should render as an SVG diagram', async () => {
   const svg = page.locator('.rendered-markdown-view svg');
   await expect(svg.first()).toBeVisible({ timeout: 10000 });
 });
+
+Then(
+  'the saved review should include comments for {string}:',
+  async ({}, filePath: string, table: DataTable) => {
+    const page = getPage();
+    const rawState = await page.locator('#review-state').textContent();
+    expect(rawState).not.toBeNull();
+    const state = JSON.parse(rawState ?? '{}') as ReviewState;
+    const file = state.files.find(candidate => candidate.path === filePath);
+    expect(file).toBeDefined();
+
+    for (const row of table.hashes()) {
+      const comment = file?.comments.find(candidate => candidate.body === row.body);
+      expect(comment).toBeDefined();
+      expect(comment?.lineRange).toEqual({
+        side: row.side,
+        start: Number(row.start),
+        end: Number(row.end),
+      });
+    }
+  }
+);

--- a/tests/webapp-steps/app.ts
+++ b/tests/webapp-steps/app.ts
@@ -11,6 +11,11 @@ import * as http from 'http';
 const VITE_PORT = 5199;
 const VITE_URL = `http://localhost:${VITE_PORT}`;
 const VITE_CONFIG = path.resolve(__dirname, '../webapp/vite.config.ts');
+const VITE_BIN = path.resolve(
+  __dirname,
+  '../../node_modules/.bin',
+  process.platform === 'win32' ? 'vite.cmd' : 'vite'
+);
 
 let viteProcess: ChildProcess | null = null;
 let browser: Browser | null = null;
@@ -60,7 +65,7 @@ async function startViteServer(): Promise<void> {
   // Kill any orphaned process on our port
   killPortProcess(VITE_PORT);
 
-  viteProcess = spawn('npx', ['vite', '--config', VITE_CONFIG], {
+  viteProcess = spawn(VITE_BIN, ['--config', VITE_CONFIG], {
     cwd: path.resolve(__dirname, '../..'),
     stdio: ['pipe', 'pipe', 'pipe'],
     env: { ...process.env, NO_COLOR: '1' },

--- a/tests/webapp/fixture-data.ts
+++ b/tests/webapp/fixture-data.ts
@@ -363,6 +363,45 @@ const markdownNewDocsFile: DiffFile = {
   ],
 };
 
+// ── Rendered HTML fixture data ──
+
+const renderedHtmlLines = [
+  '<main>',
+  '  <h1>Release Notes</h1>',
+  '  <p>Intro paragraph for rendered review.</p>',
+  '  <section>',
+  '    <h2>Highlights</h2>',
+  '    <p>Second paragraph for another comment.</p>',
+  '    <ul>',
+  '      <li>First listed item</li>',
+  '      <li>Second listed item</li>',
+  '    </ul>',
+  '  </section>',
+  '</main>',
+];
+
+const renderedHtmlFile: DiffFile = {
+  oldPath: '/dev/null',
+  newPath: 'docs/page.html',
+  changeType: 'added',
+  isBinary: false,
+  hunks: [
+    {
+      header: `@@ -0,0 +1,${renderedHtmlLines.length} @@`,
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: renderedHtmlLines.length,
+      lines: renderedHtmlLines.map((line, i) => ({
+        type: 'addition' as const,
+        oldLineNumber: null,
+        newLineNumber: i + 1,
+        content: line,
+      })),
+    },
+  ],
+};
+
 const markdownIndexLines = [
   "export const version = '1.0.0';",
 ];
@@ -414,6 +453,13 @@ const markdownReadmeFile: DiffFile = {
 export function createMarkdownPayload(): DiffLoadPayload {
   return {
     files: [markdownNewDocsFile, markdownIndexFile, markdownReadmeFile],
+    source: { type: 'git' as const, gitDiffArgs: '', repository: '/mock-test-repo' },
+  };
+}
+
+export function createRenderedHtmlPayload(): DiffLoadPayload {
+  return {
+    files: [renderedHtmlFile, markdownNewDocsFile, markdownIndexFile, markdownReadmeFile],
     source: { type: 'git' as const, gitDiffArgs: '', repository: '/mock-test-repo' },
   };
 }

--- a/tests/webapp/main.tsx
+++ b/tests/webapp/main.tsx
@@ -7,7 +7,7 @@ import {
 import type { ReviewPanelHandle } from '../../packages/react/src/index';
 import type { ReviewAdapter } from '../../packages/react/src/adapter';
 import type { AppConfig, DiffLoadPayload, CategoryDef } from '../../packages/core/src/types';
-import { createFixturePayload, createEmptyPayload, createMarkdownPayload, defaultCategories, commentingCategories } from './fixture-data';
+import { createFixturePayload, createEmptyPayload, createMarkdownPayload, createRenderedHtmlPayload, defaultCategories, commentingCategories } from './fixture-data';
 import './styles.css';
 
 /**
@@ -18,7 +18,7 @@ import './styles.css';
  * read the review state when ready.
  *
  * URL parameters control behavior:
- * - ?fixture=empty|markdown   — Select fixture dataset (default: full fixture)
+ * - ?fixture=empty|markdown|rendered-html   — Select fixture dataset (default: full fixture)
  * - ?gitDiffArgs=...          — Pass gitDiffArgs to empty fixture
  * - ?categories=commenting    — Use commenting test categories (bug, nit, question)
  * - ?theme=dark|light         — Set initial theme
@@ -57,6 +57,7 @@ function getFixturePayload(): DiffLoadPayload {
   const gitDiffArgs = getUrlParam('gitDiffArgs') ?? undefined;
   if (fixture === 'empty') return createEmptyPayload(gitDiffArgs);
   if (fixture === 'markdown') return createMarkdownPayload();
+  if (fixture === 'rendered-html') return createRenderedHtmlPayload();
   return createFixturePayload();
 }
 

--- a/vitest.config.main.ts
+++ b/vitest.config.main.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from 'vitest/config';
 import path from 'path';
 
-export default defineConfig({
+export default {
   test: {
     environment: 'node',
     include: ['src/main/**/*.test.ts'],
@@ -36,4 +35,4 @@ export default defineConfig({
       '**/*.d.ts',
     ],
   },
-});
+};

--- a/vitest.config.renderer.ts
+++ b/vitest.config.renderer.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from 'vitest/config';
 import path from 'path';
 
-export default defineConfig({
+export default {
   test: {
     environment: 'jsdom',
     include: ['packages/react/src/**/*.test.{ts,tsx}'],
@@ -38,4 +37,4 @@ export default defineConfig({
       'src/renderer/components/**/*', // UI components not tested initially
     ],
   },
-});
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from 'vitest/config';
 import path from 'path';
 
-export default defineConfig({
+export default {
   test: {
     // By default, exclude e2e tests and generated files
     include: ['src/**/*.test.{ts,tsx}'],
@@ -37,4 +36,4 @@ export default defineConfig({
       'src/renderer/components/**/*',
     ],
   },
-});
+};


### PR DESCRIPTION
## Summary

- Extends the rendered-text preview pipeline so newly added HTML (`.html`, `.htm`) files render through the same wrapper as Markdown, with line-range gutter comments, file-level comments, and existing comment display all flowing through one path.
- Strips executable / external-loading surfaces from rendered HTML to preserve the no-network and bundled-assets guarantees. Modified and deleted HTML files keep the raw diff view; SVG raw preview defaults are preserved.
- Adds renderer and webapp e2e coverage for HTML rendered review (including saved new-line ranges) and regression coverage for Markdown rendered review.

Closes #95.

## Test plan

- [ ] `npm run test:unit` passes
- [ ] `npm run test:e2e` passes (webapp e2e covers `09-rendered-html.feature`)
- [ ] Manually open a diff with an added `.html` file and confirm the Raw/Rendered toggle appears and works
- [ ] Add a line-range comment on the rendered HTML view and verify it persists against new-file lines
- [ ] Confirm modified and deleted HTML files still render as raw diff only
- [ ] Confirm added Markdown rendered preview still works without regression