### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/.cursor/cloud-instructions.md
+++ b/.cursor/cloud-instructions.md
@@ -1,0 +1,14 @@
+# Cursor Cloud specific instructions
+
+Durable, non-obvious setup/run caveats for developing this repo inside a Cursor Cloud Agent VM. Standard commands and conventions live in [`AGENTS.md`](../AGENTS.md).
+
+Dependencies are installed automatically on VM startup (`npm install`, which also links the `packages/*` workspaces). Node 22+ and a virtual display (`DISPLAY=:1`, xvfb) are present.
+
+- **Build the workspace packages before `npm start` / `npm run package`.** The webpack build imports the `@self-review/types` (and `core`/`react`) package specifiers, which resolve to each package's `dist/` — **not** built by `npm install`. Run once after a fresh install:
+  `npm run build --workspace=packages/types && npm run build --workspace=packages/core && npm run build --workspace=packages/react`
+  Skipping this fails the build with `Cannot find module '@self-review/types'`. Unit tests still pass without it because those are type-only imports (erased at transform).
+- **Running the actual Electron app headless:** package it (`npm run package`), then launch the binary from inside the target git repo so its `git diff` runs there:
+  `cd <repo-with-changes> && DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 "/agent/repos/self-review/out/Self Review-linux-x64/self-review"`.
+  Use the `ELECTRON_DISABLE_SANDBOX=1` **env var**, never the `--no-sandbox` flag — any unrecognized CLI arg is forwarded to `git diff` and breaks startup. The review is written to `./review.xml` in that cwd on "Finish Review".
+  Caveat: the packaged binary's asar omits `xmllint.wasm`, so it emits XML *without* XSD validation (logs a warning); dev mode (`npm start`) ships the wasm under `.webpack/` and validates normally.
+- **e2e browsers are separate per Playwright version.** `npm run test:e2e` (webapp, the CI suite, 51 tests) needs `npx playwright install chromium chromium-headless-shell` first — it does **not** auto-install. Electron e2e (`npm run test:e2e:electron`) additionally packages + uses xvfb. Unit suites (`npm run test:unit`, 187 tests) and `npm run lint` need no browser and pass green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,18 @@ the single source of truth for the XML output format.
 
 Make sure the PR title follows the conventional commit naming convention.
 
+## Cursor Cloud specific instructions
+
+Dependencies are installed automatically on VM startup (`npm install`, which also links the `packages/*` workspaces). Node 22+ and a virtual display (`DISPLAY=:1`, xvfb) are present.
+
+- **Build the workspace packages before `npm start` / `npm run package`.** The webpack build imports the `@self-review/types` (and `core`/`react`) package specifiers, which resolve to each package's `dist/` — **not** built by `npm install`. Run once after a fresh install:
+  `npm run build --workspace=packages/types && npm run build --workspace=packages/core && npm run build --workspace=packages/react`
+  Skipping this fails the build with `Cannot find module '@self-review/types'`. Unit tests still pass without it because those are type-only imports (erased at transform).
+- **Running the actual Electron app headless:** package it (`npm run package`), then launch the binary from inside the target git repo so its `git diff` runs there:
+  `cd <repo-with-changes> && DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 "/agent/repos/self-review/out/Self Review-linux-x64/self-review"`.
+  Use the `ELECTRON_DISABLE_SANDBOX=1` **env var**, never the `--no-sandbox` flag — any unrecognized CLI arg is forwarded to `git diff` and breaks startup. The review is written to `./review.xml` in that cwd on "Finish Review".
+  Caveat: the packaged binary's asar omits `xmllint.wasm`, so it emits XML *without* XSD validation (logs a warning); dev mode (`npm start`) ships the wasm under `.webpack/` and validates normally.
+- **e2e browsers are separate per Playwright version.** `npm run test:e2e` (webapp, the CI suite, 51 tests) needs `npx playwright install chromium chromium-headless-shell` first — it does **not** auto-install. Electron e2e (`npm run test:e2e:electron`) additionally packages + uses xvfb. Unit suites (`npm run test:unit`, 187 tests) and `npm run lint` need no browser and pass green.
 
 <!-- >>> kenkeep:kk-index >>> -->
 Curated project knowledge lives in [.ai/kenkeep/INDEX.md](.ai/kenkeep/INDEX.md). Consult it before designing a non-trivial change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,16 +336,7 @@ Make sure the PR title follows the conventional commit naming convention.
 
 ## Cursor Cloud specific instructions
 
-Dependencies are installed automatically on VM startup (`npm install`, which also links the `packages/*` workspaces). Node 22+ and a virtual display (`DISPLAY=:1`, xvfb) are present.
-
-- **Build the workspace packages before `npm start` / `npm run package`.** The webpack build imports the `@self-review/types` (and `core`/`react`) package specifiers, which resolve to each package's `dist/` — **not** built by `npm install`. Run once after a fresh install:
-  `npm run build --workspace=packages/types && npm run build --workspace=packages/core && npm run build --workspace=packages/react`
-  Skipping this fails the build with `Cannot find module '@self-review/types'`. Unit tests still pass without it because those are type-only imports (erased at transform).
-- **Running the actual Electron app headless:** package it (`npm run package`), then launch the binary from inside the target git repo so its `git diff` runs there:
-  `cd <repo-with-changes> && DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 "/agent/repos/self-review/out/Self Review-linux-x64/self-review"`.
-  Use the `ELECTRON_DISABLE_SANDBOX=1` **env var**, never the `--no-sandbox` flag — any unrecognized CLI arg is forwarded to `git diff` and breaks startup. The review is written to `./review.xml` in that cwd on "Finish Review".
-  Caveat: the packaged binary's asar omits `xmllint.wasm`, so it emits XML *without* XSD validation (logs a warning); dev mode (`npm start`) ships the wasm under `.webpack/` and validates normally.
-- **e2e browsers are separate per Playwright version.** `npm run test:e2e` (webapp, the CI suite, 51 tests) needs `npx playwright install chromium chromium-headless-shell` first — it does **not** auto-install. Electron e2e (`npm run test:e2e:electron`) additionally packages + uses xvfb. Unit suites (`npm run test:unit`, 187 tests) and `npm run lint` need no browser and pass green.
+When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (building the workspace packages before the app builds, the headless Electron launch recipe, e2e browser install). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
 Curated project knowledge lives in [.ai/kenkeep/INDEX.md](.ai/kenkeep/INDEX.md). Consult it before designing a non-trivial change.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the non-obvious setup/run details for developing this repo in a Cursor Cloud Agent VM. The detail lives in a standalone **`.cursor/cloud-instructions.md`** and `AGENTS.md` carries a short on-demand pointer (loaded only when relevant, not inline).

Captured guidance:
- **Workspace packages must be built before `npm start`/`npm run package`.** Webpack imports the `@self-review/types`/`core`/`react` package specifiers (resolving to each package's `dist/`), which `npm install` does not build — skipping fails with `Cannot find module '@self-review/types'`. Unit tests pass without it (type-only imports erased at transform).
- **Running the Electron app headless:** package, then launch the binary from inside the target git repo with `DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1` — never the `--no-sandbox` flag (unrecognized args are forwarded to `git diff`). Packaged binary omits `xmllint.wasm` so it emits XML without XSD validation (dev mode validates).
- **e2e browsers are per Playwright version:** webapp e2e needs `npx playwright install chromium chromium-headless-shell` first (no auto-install).

## Verification

All run from a fresh install in the Cloud VM:
- `npm run lint` — pass
- `npm run test:unit` — 187 tests pass (44 main + 143 renderer)
- `npm run test:e2e` — 51 webapp e2e tests pass
- `npm run package` + launched the packaged Electron app on a real diff, added an inline review comment, clicked Finish Review, and confirmed a valid `review.xml` was written.

No source code changes; docs only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63bb6dce-6c5d-46f9-8c79-53a165d64ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63bb6dce-6c5d-46f9-8c79-53a165d64ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

