### PR TITLE
feat: add Linux zip to release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,18 @@ jobs:
 
       - name: Upload release assets
         if: steps.tag.outputs.tag != ''
-        run: gh release upload "${{ steps.tag.outputs.tag }}" out/make/deb/x64/*.deb out/make/rpm/x64/*.rpm --clobber
+        run: |
+          # Rename the zip (productName has a space: "Self Review-…") to a clean filename
+          VERSION="${{ steps.tag.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          ZIP_SRC="out/make/zip/linux/x64/Self Review-${VERSION}-linux-x64.zip"
+          ZIP_DST="out/make/zip/linux/x64/self-review-${VERSION}-linux-x64.zip"
+          mv "$ZIP_SRC" "$ZIP_DST"
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            out/make/deb/x64/*.deb \
+            out/make/rpm/x64/*.rpm \
+            "$ZIP_DST" \
+            --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,18 +89,7 @@ jobs:
 
       - name: Upload release assets
         if: steps.tag.outputs.tag != ''
-        run: |
-          # Rename the zip (productName has a space: "Self Review-…") to a clean filename
-          VERSION="${{ steps.tag.outputs.tag }}"
-          VERSION="${VERSION#v}"
-          ZIP_SRC="out/make/zip/linux/x64/Self Review-${VERSION}-linux-x64.zip"
-          ZIP_DST="out/make/zip/linux/x64/self-review-${VERSION}-linux-x64.zip"
-          mv "$ZIP_SRC" "$ZIP_DST"
-          gh release upload "${{ steps.tag.outputs.tag }}" \
-            out/make/deb/x64/*.deb \
-            out/make/rpm/x64/*.rpm \
-            "$ZIP_DST" \
-            --clobber
+        run: gh release upload "${{ steps.tag.outputs.tag }}" out/make/deb/x64/*.deb out/make/rpm/x64/*.rpm out/make/zip/linux/x64/*.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -54,7 +54,7 @@ const config: ForgeConfig = {
   rebuildConfig: {},
   makers: [
     new MakerSquirrel({}),
-    new MakerZIP({}, ['darwin']),
+    new MakerZIP({}, ['darwin', 'linux']),
     new MakerRpm({
       options: {
         name: 'self-review',


### PR DESCRIPTION
Enables MakerZIP for linux in forge.config.ts and uploads the resulting zip as a GitHub release asset alongside the existing .deb and .rpm. The zip provides a distro-agnostic archive for Nix and other package managers that prefer extracting a pre-built binary directly. See #101 .