### PR TITLE
ci: modernize GitHub Actions to Node 24 LTS and upgrade actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -33,10 +33,10 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm run test:unit
@@ -45,15 +45,15 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: e2e-test-results

--- a/.github/workflows/release-darwin.yml
+++ b/.github/workflows/release-darwin.yml
@@ -27,13 +27,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
       - name: Restore branch ref for semantic-release
         run: git checkout -B ${{ github.event.workflow_run.head_branch }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/update-flake-hash.yml
+++ b/.github/workflows/update-flake-hash.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: DeterminateSystems/nix-installer-action@main
 
@@ -33,7 +33,7 @@ jobs:
         run: |
           sed -i 's|hash = "sha256-.*"|hash = "${{ steps.hash.outputs.hash }}"|' flake.nix
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: update flake hash for ${{ inputs.tag }}"
           title: "chore: update flake hash for ${{ inputs.tag }}"


### PR DESCRIPTION
Upgrade Node.js from 22 to 24 (Active LTS) in ci.yml and release-darwin.yml. Bump first-party and third-party actions to their latest stable majors: actions/checkout v7, actions/setup-node v6, actions/upload-artifact v7, peter-evans/create-pull-request v8.

The checkout v7 fork-PR block only fires for PR-triggered pull_request_target/workflow_run events; release.yml restricts to pushes on main, so it is unaffected.

Closes #104