### PR TITLE
feat: add Help menu with Documentation link and About dialog

### DIFF
--- a/src/main/app-assets.ts
+++ b/src/main/app-assets.ts
@@ -1,0 +1,33 @@
+// src/main/app-assets.ts
+// Resolves bundled application assets (icon) for both dev and packaged builds.
+
+import { app } from 'electron';
+import { join } from 'path';
+import { promises as fs } from 'fs';
+
+/**
+ * Absolute path to the application icon (PNG).
+ *
+ * In a packaged app the icon is copied into the resources directory via
+ * `extraResource` (see forge.config.ts). In development it lives in the repo's
+ * `assets/` directory, two levels up from the bundled main process output
+ * (`.webpack/main`).
+ */
+export function getAppIconPath(): string {
+  return app.isPackaged
+    ? join(process.resourcesPath, 'icon.png')
+    : join(__dirname, '..', '..', 'assets', 'icon.png');
+}
+
+/**
+ * Read the application icon and return it as a base64 `data:` URI suitable for
+ * an `<img src>` in the renderer. Returns null if the icon cannot be read.
+ */
+export async function getAppIconDataUri(): Promise<string | null> {
+  try {
+    const data = await fs.readFile(getAppIconPath());
+    return `data:image/png;base64,${data.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -23,10 +23,15 @@ vi.mock('electron', () => ({
   },
   app: {
     getPath: vi.fn(),
+    getVersion: vi.fn(() => '9.9.9'),
   },
   shell: {
     openExternal: vi.fn(),
   },
+}));
+
+vi.mock('./app-assets', () => ({
+  getAppIconDataUri: vi.fn(async () => 'data:image/png;base64,ICON'),
 }));
 
 vi.mock('./version-checker', () => ({
@@ -150,6 +155,19 @@ describe('ipc-handlers', () => {
       const handler = handlers[IPC.DIFF_LOAD_FILE];
       const result = await handler({}, 'src/deleted.ts');
       expect(result).toEqual(file.hunks);
+    });
+  });
+
+  describe('APP_GET_INFO handler', () => {
+    it('returns the app version and icon data URI', async () => {
+      const handler = handlers[IPC.APP_GET_INFO];
+      expect(handler).toBeDefined();
+
+      const result = await handler({});
+      expect(result).toEqual({
+        version: '9.9.9',
+        iconDataUri: 'data:image/png;base64,ICON',
+      });
     });
   });
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -16,10 +16,12 @@ import {
   ExpandContextRequest,
   FindInPageRequest,
   ImageLoadResult,
+  AppInfo,
 } from '../shared/types';
 import { scanDirectory, scanFile } from './directory-scanner';
 import { getVersionUpdate } from './version-checker';
 import { computePayloadStats, countTotalLines } from './payload-sizing';
+import { getAppIconDataUri } from './app-assets';
 
 let reviewStateCache: ReviewState | null = null;
 let diffDataCache: DiffLoadPayload | null = null;
@@ -93,6 +95,14 @@ export function registerIpcHandlers(): void {
     if (configCache) {
       event.sender.send(IPC.CONFIG_LOAD, configCache, outputPathInfoCache);
     }
+  });
+
+  // Handle app info request from renderer (version + icon for the About dialog)
+  ipcMain.handle(IPC.APP_GET_INFO, async (): Promise<AppInfo> => {
+    return {
+      version: app.getVersion(),
+      iconDataUri: await getAppIconDataUri(),
+    };
   });
 
   // Handle review submission from renderer

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,7 +4,7 @@
 import { app, BrowserWindow, dialog, ipcMain, nativeImage } from 'electron';
 import { writeFileSync, existsSync, statSync } from 'fs';
 import { execSync } from 'child_process';
-import { resolve, join } from 'path';
+import { resolve } from 'path';
 import { checkWritability } from './fs-utils';
 import { parseCliArgs, checkEarlyExit, normalizeGitDiffArgs } from './cli';
 import { loadGitDiffWithUntracked } from './git-diff-loader';
@@ -25,6 +25,8 @@ import {
 } from './ipc-handlers';
 import { checkForUpdate } from './version-checker';
 import { computePayloadStats, countTotalLines } from './payload-sizing';
+import { setupMenu } from './menu';
+import { getAppIconPath } from './app-assets';
 import { IPC } from '../shared/ipc-channels';
 import { AppConfig, DiffLoadPayload, OutputPathInfo, ReviewComment } from '../shared/types';
 
@@ -326,6 +328,10 @@ async function initializeApp() {
     console.error('[main] Registering IPC handlers');
     registerIpcHandlers();
 
+    // Phase 7b: Setup menu
+    console.error('[main] Setting up menu');
+    setupMenu();
+
     // Phase 8: Create window
     console.error('[main] Creating window');
     createWindow();
@@ -357,10 +363,7 @@ async function initializeApp() {
 function createWindow(): void {
   // On Linux, set the window icon explicitly so alt+tab and taskbar show
   // the correct icon. macOS uses the .icns from the app bundle automatically.
-  const iconPath = app.isPackaged
-    ? join(process.resourcesPath, 'icon.png')
-    : join(__dirname, '..', '..', 'assets', 'icon.png');
-  const iconImage = nativeImage.createFromPath(iconPath);
+  const iconImage = nativeImage.createFromPath(getAppIconPath());
 
   mainWindow = new BrowserWindow({
     width: 1400,

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,0 +1,41 @@
+// src/main/menu.ts
+// Builds the application menu. Standard menus (File/Edit/View/Window) use
+// Electron's built-in role submenus so they match the platform defaults
+// automatically; only the Help menu is customized.
+
+import { Menu, shell, BrowserWindow, type MenuItemConstructorOptions } from 'electron';
+import { IPC } from '../shared/ipc-channels';
+
+const DOCUMENTATION_URL = 'https://github.com/e0ipso/self-review#self-review-';
+
+export function setupMenu(): void {
+  const isMac = process.platform === 'darwin';
+
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac ? [{ role: 'appMenu' as const }] : []),
+    { role: 'fileMenu' },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Documentation',
+          click: () => {
+            shell.openExternal(DOCUMENTATION_URL);
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'About',
+          click: () => {
+            BrowserWindow.getFocusedWindow()?.webContents.send(IPC.APP_SHOW_ABOUT);
+          },
+        },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -119,4 +119,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   loadImage: (filePath: string) =>
     ipcRenderer.invoke(IPC.DIFF_LOAD_IMAGE, filePath),
+
+  onShowAbout: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on(IPC.APP_SHOW_ABOUT, handler);
+    return () => ipcRenderer.removeListener(IPC.APP_SHOW_ABOUT, handler);
+  },
+
+  getAppInfo: () => ipcRenderer.invoke(IPC.APP_GET_INFO),
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from '../../packages/react/src/components/ui/tooltip'
 import Toolbar from '../../packages/react/src/components/Toolbar';
 import Layout from '../../packages/react/src/components/Layout';
 import CloseConfirmDialog from './components/CloseConfirmDialog';
+import AboutDialog from './components/AboutDialog';
 import { KeyboardNavigationManager } from '../../packages/react/src/components/KeyboardNavigationManager';
 import { FindBar } from './components/FindBar';
 import WelcomeScreen from './components/WelcomeScreen';
@@ -138,6 +139,7 @@ function AppContent() {
         </div>
         <FindBar isOpen={isFindBarOpen} onClose={() => setIsFindBarOpen(false)} />
         <CloseConfirmDialog />
+        <AboutDialog />
       </TooltipProvider>
     </DiffNavigationProvider>
   );

--- a/src/renderer/components/AboutDialog.tsx
+++ b/src/renderer/components/AboutDialog.tsx
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../../../packages/react/src/components/ui/alert-dialog';
+import type { AppInfo } from '../../shared/types';
+
+const REPOSITORY_URL = 'https://github.com/e0ipso/self-review';
+
+export default function AboutDialog() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.onShowAbout(() => setIsOpen(true));
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    window.electronAPI.getAppInfo().then(setAppInfo).catch(() => {
+      // App info unavailable — the dialog still renders without it.
+    });
+  }, []);
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader className="items-center text-center">
+          {appInfo?.iconDataUri && (
+            <img
+              src={appInfo.iconDataUri}
+              alt="self-review"
+              className="w-16 h-16 mb-4"
+            />
+          )}
+          <AlertDialogTitle className="text-center">self-review</AlertDialogTitle>
+          <AlertDialogDescription className="text-center pt-2">
+            <span className="block space-y-1 text-sm">
+              {appInfo && <span className="block">Version {appInfo.version}</span>}
+              <span className="block text-xs text-muted-foreground">
+                GitHub-style PR review UI for local git diffs
+              </span>
+              <span className="block text-xs text-muted-foreground pt-2">
+                © 2026 Mateu Aguiló Bosch
+              </span>
+              <span className="block text-xs">
+                <a
+                  href={REPOSITORY_URL}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    window.electronAPI.openExternal(REPOSITORY_URL);
+                  }}
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  github.com/e0ipso/self-review
+                </a>
+              </span>
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogAction onClick={() => setIsOpen(false)}>OK</AlertDialogAction>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -27,4 +27,6 @@ export const IPC = {
   DIFF_LOAD_FILE: 'diff:load-file',
   PAYLOAD_GUARD_SHOW: 'payload-guard:show',
   DIFF_LOAD_IMAGE: 'diff:load-image',
+  APP_SHOW_ABOUT: 'app:show-about',
+  APP_GET_INFO: 'app:get-info',
 } as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,6 +30,14 @@ export type {
 // ===== Electron API (preload bridge) =====
 // Electron-specific — not part of @self-review/types.
 
+/** Application metadata shown in the About dialog. */
+export interface AppInfo {
+  /** App version, from package.json via app.getVersion(). */
+  version: string;
+  /** App icon as a base64 data URI, or null if it could not be loaded. */
+  iconDataUri: string | null;
+}
+
 import type {
   DiffLoadPayload,
   AppConfig,
@@ -68,6 +76,8 @@ export interface ElectronAPI {
   onFindResult: (callback: (result: FindInPageResult) => void) => () => void;
   requestVersionUpdate: () => void;
   onVersionUpdate: (callback: (info: VersionUpdateInfo) => void) => void;
+  onShowAbout: (callback: () => void) => () => void;
+  getAppInfo: () => Promise<AppInfo>;
   openExternal: (url: string) => Promise<void>;
   loadFileContent: (filePath: string) => Promise<DiffHunk[]>;
   loadImage: (filePath: string) => Promise<ImageLoadResult>;


### PR DESCRIPTION
## Summary

Populates the previously-empty **Help** menu with two items:

- **Documentation** — opens the repository README in the default browser.
- **About** — opens a modal showing the app icon, version, and copyright.

<!-- 📸 Drag about.png here to attach the About-dialog screenshot -->
<img width="1360" height="856" alt="about" src="https://github.com/user-attachments/assets/6b0ea168-8200-45a6-bc4f-07efa0f00def" />


## Details

- The application menu is now built from Electron **role submenus**
  (`fileMenu`/`editMenu`/`viewMenu`/`windowMenu`), so the standard menus match
  platform defaults automatically; only **Help** is customized.
- The About dialog fetches version and icon through a single `app:get-info`
  IPC handler. The icon is read in the **main process** from its real location
  (`process.resourcesPath` when packaged, `assets/` in dev) and returned as a
  base64 data URI — so it renders regardless of the current working directory.
- `getAppIconPath()` / `getAppIconDataUri()` are extracted into
  `src/main/app-assets.ts` and reused by `createWindow()`, removing duplicated
  icon-path logic.
- Adds a unit test for the `app:get-info` handler.

## Test plan

- [x] `npm run test:unit` — 188 unit tests pass (incl. new `app:get-info` test)
- [x] `npm run lint` — clean
- [x] App boots to full initialization; Help → Documentation opens the browser,
      Help → About shows the dialog with the app icon and dynamic version.