### PR TITLE
fix: emit xmllint.wasm alongside its relocated loader

### DIFF
--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -22,7 +22,13 @@ export const mainConfig: Configuration = {
       patterns: [
         {
           from: 'node_modules/xmllint-wasm/xmllint.wasm',
-          to: 'xmllint.wasm',
+          // Must match the path the asset relocator rewrites xmllint-node.js's
+          // wasm reference to. webpack.rules.ts runs
+          // @vercel/webpack-asset-relocator-loader with
+          // outputAssetBase: 'native_modules', so the bundled loader requests
+          // native_modules/xmllint.wasm. Emitting to the output root instead
+          // leaves validation permanently unavailable in packaged builds.
+          to: 'native_modules/xmllint.wasm',
         },
       ],
     }),


### PR DESCRIPTION
Closes #121.

## Problem

`webpack.main.config.ts` copied `xmllint.wasm` to the webpack main output root, but `webpack.rules.ts` runs `@vercel/webpack-asset-relocator-loader` with `outputAssetBase: 'native_modules'`. That relocates `xmllint-node.js` into `native_modules/` and leaves it resolving its wasm relative to its own directory, so packaged builds requested `.webpack/main/native_modules/xmllint.wasm` and got ENOENT inside `app.asar`.

Two silent consequences:

1. **Guided walkthrough mode was inert in every packaged 1.40.0 install.** `guide-parser.ts` has no infrastructure-failure fallback, so a valid `review.guide.xml` was always dropped and the app fell back to the flat tree with one stderr warning.
2. **`review.xml` was written unvalidated in packaged builds.** `xml-serializer.ts` catches the wasm load failure and emits the XML anyway with only a stderr warning, contradicting the "XML must validate" guarantee in `AGENTS.md`.

Dev builds resolved the wasm correctly, which is why this went unnoticed.

## Cause

Regression from `.ai/strikethroo/archive/08--fix-production-xml-output`, which moved the copy target to the output root on the premise that xmllint-wasm resolves via `__dirname + "/xmllint.wasm"`. True of the raw package, false after the relocator rewrites the reference. The original placement from `archive/03--fix-xmllint-wasm` was correct.

## Fix

One line: `to: 'native_modules/xmllint.wasm'`. `asarUnpack: ['**/xmllint.wasm']` already matches the nested path, so `forge.config.ts` needs no change. A comment now records the coupling to the relocator so the premise is not re-applied.

## Verification

- Webpack build emits `.webpack/main/native_modules/xmllint.wasm`, alongside the relocated `native_modules/xmllint-node.js` whose bundled loader resolves `m + "xmllint.wasm"` relative to its own directory.
- Confirmed working end to end from source against a real guide sidecar: guided mode renders groups, per-file descriptions, and the Mermaid overview.
- Unit suite green (230 tests, via the pre-commit hook).

## Follow-ups (not in this PR)

- The `catch` in `xml-serializer.ts` that downgrades an unloadable validator to a stderr warning is what hid this across several releases. Tightening it to `exit(1)` would restore the documented guarantee.
- Nothing tests the packaged wasm layout — invisible to unit tests and dev-mode e2e by construction.