### PR TITLE
fix: preserve clone transport fallback

### DIFF
--- a/.ai/kenkeep/ENTRY.md
+++ b/.ai/kenkeep/ENTRY.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 3
-nodes_hash: 'sha256:6dd78e566f7b94f6cb212c57abc9cb96c6e585e39ba939cb6a91d276cbe50c78'
+nodes_hash: 'sha256:3b49bca508c6c49b8ee9fd68f18ab17ab5667712e31ac5e0f7f644dbb32cdb01'
 node_count: 175
 ---
 # kenkeep

--- a/.ai/kenkeep/GRAPH.md
+++ b/.ai/kenkeep/GRAPH.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 3
-nodes_hash: 'sha256:6dd78e566f7b94f6cb212c57abc9cb96c6e585e39ba939cb6a91d276cbe50c78'
+nodes_hash: 'sha256:3b49bca508c6c49b8ee9fd68f18ab17ab5667712e31ac5e0f7f644dbb32cdb01'
 node_count: 175
 ---
 # kenkeep Graph

--- a/.ai/kenkeep/nodes/app/cli/index.md
+++ b/.ai/kenkeep/nodes/app/cli/index.md
@@ -63,7 +63,7 @@ _None._
 - Open [**Three startup modes: git, directory, welcome**](map-three-startup-modes-git-directory-welcome.md) — git mode reviews a git diff; directory mode treats all files as new additions; welcome mode shows a picker when launched without context.
 ### #output
 - Open [**Design XML output to be parsed by LLMs**](../../review-xml/schema/practice-design-xml-output-to-be-parsed-by-llms.md) — Review output is structured XML with an XSD schema so LLMs can reliably parse and act on feedback.
-- Open [**self-review-v3 XSD output format**](../../review-xml/schema/map-self-review-v1-xsd-output-format.md) — Review output uses self-review-v3.xsd and urn:self-review:v3; v1 and v2 schemas remain frozen for older consumers.
+- Open [**self-review-v3 XSD output format**](../../review-xml/schema/map-self-review-v1-xsd-output-format.md) — Review output uses self-review-v3.xsd and urn:self-review:v3; v1 and v2 stay frozen, while the current version may gain optional attributes additively.
 - Open [**Treat self-review as a CLI-first, one-shot tool**](practice-treat-self-review-as-a-cli-first-one-shot-tool.md) — self-review launches from the terminal, writes review output to a file, then exits. No servers or persistent state.
 ### #staged
 - Open [**Hide untracked files by default for --staged/--cached reviews**](practice-hide-untracked-files-by-default-for-staged-cached-reviews.md) — Index-vs-HEAD reviews hide untracked files by default since they aren't part of the index; users can reveal them via toolbar toggle.

--- a/.ai/kenkeep/nodes/app/index.md
+++ b/.ai/kenkeep/nodes/app/index.md
@@ -14,9 +14,9 @@
 
 ## Conventions (how we build)
 - Open [**Keep self-review local-only with no network access**](practice-keep-self-review-local-only-with-no-network-access.md) to learn about: No network access, no accounts, no telemetry. Code stays on the user's machine. #privacy #network #local
-- Open [**Limit file writes to the review XML and assets directory**](practice-limit-file-writes-to-the-review-xml-and-assets-directory.md) to learn about: App only writes the configured output XML file and a sibling .self-review-assets/ directory for image attachments. #task-manager #filesystem #scope
-- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) to learn about: The app is fully local: no network calls, no telemetry, no analytics, no CDN fetches. #network #privacy #local-only
-- Open [**Make zero network requests except the startup version check**](practice-make-zero-network-requests-except-the-startup-version-check.md) to learn about: No telemetry, analytics, or CDN fetches; only a fire-and-forget GitHub Releases check at startup. #task-manager #network #privacy
+- Open [**Limit file writes to the review XML and assets directory**](practice-limit-file-writes-to-the-review-xml-and-assets-directory.md) to learn about: App writes only the output XML, a sibling .self-review-assets/ directory, and (remote mode) a temporary clone under the OS temp dir, removed on exit. #task-manager #filesystem #scope
+- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) to learn about: The app is local-first: no network calls except the startup version check and user-triggered remote PR/MR review; nothing is sent to the forge. #network #privacy #local-only
+- Open [**Make zero network requests except the startup version check**](practice-make-zero-network-requests-except-the-startup-version-check.md) to learn about: No telemetry, analytics, or CDN fetches; only the startup version check and user-triggered remote PR/MR review touch the network. #task-manager #network #privacy
 
 ## Components (what exists)
 - Open [**self-review**](map-self-review.md) to learn about: Local-only Electron desktop app providing a GitHub-style PR review UI for local git diffs and directory reviews. #task-manager #app #overview
@@ -26,12 +26,12 @@
 
 ### #network
 - Open [**Keep self-review local-only with no network access**](practice-keep-self-review-local-only-with-no-network-access.md) — No network access, no accounts, no telemetry. Code stays on the user's machine.
-- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) — The app is fully local: no network calls, no telemetry, no analytics, no CDN fetches.
-- Open [**Make zero network requests except the startup version check**](practice-make-zero-network-requests-except-the-startup-version-check.md) — No telemetry, analytics, or CDN fetches; only a fire-and-forget GitHub Releases check at startup.
+- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) — The app is local-first: no network calls except the startup version check and user-triggered remote PR/MR review; nothing is sent to the forge.
+- Open [**Make zero network requests except the startup version check**](practice-make-zero-network-requests-except-the-startup-version-check.md) — No telemetry, analytics, or CDN fetches; only the startup version check and user-triggered remote PR/MR review touch the network.
 ### #privacy
 - Open [**Keep self-review local-only with no network access**](practice-keep-self-review-local-only-with-no-network-access.md) — No network access, no accounts, no telemetry. Code stays on the user's machine.
-- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) — The app is fully local: no network calls, no telemetry, no analytics, no CDN fetches.
-- Open [**Make zero network requests except the startup version check**](practice-make-zero-network-requests-except-the-startup-version-check.md) — No telemetry, analytics, or CDN fetches; only a fire-and-forget GitHub Releases check at startup.
+- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) — The app is local-first: no network calls except the startup version check and user-triggered remote PR/MR review; nothing is sent to the forge.
+- Open [**Make zero network requests except the startup version check**](practice-make-zero-network-requests-except-the-startup-version-check.md) — No telemetry, analytics, or CDN fetches; only the startup version check and user-triggered remote PR/MR review touch the network.
 ### #task-manager
 - Open [**POST_PHASE hook**](../planning/execution/map-post-phase-hook.md) — Task-manager hook that runs after each phase to enforce linting, conventional commits, and blueprint progress updates.
 - Open [**PRE_PLAN hook**](../planning/authoring/map-pre-plan-hook.md) — Pre-planning hook that establishes scope control, simplicity principles, and PRD-only output before plan creation.
@@ -43,11 +43,11 @@
 - Open [**self-review**](map-self-review.md) — Local-only Electron desktop app providing a GitHub-style PR review UI for local git diffs and directory reviews.
 - Open [**self-review application**](map-self-review-application.md) — Local-only Electron desktop app providing a GitHub-style PR review UI for local git diffs and directory reviews.
 ### #filesystem
-- Open [**Limit file writes to the review XML and assets directory**](practice-limit-file-writes-to-the-review-xml-and-assets-directory.md) — App only writes the configured output XML file and a sibling .self-review-assets/ directory for image attachments.
+- Open [**Limit file writes to the review XML and assets directory**](practice-limit-file-writes-to-the-review-xml-and-assets-directory.md) — App writes only the output XML, a sibling .self-review-assets/ directory, and (remote mode) a temporary clone under the OS temp dir, removed on exit.
 ### #local
 - Open [**Keep self-review local-only with no network access**](practice-keep-self-review-local-only-with-no-network-access.md) — No network access, no accounts, no telemetry. Code stays on the user's machine.
 ### #local-only
-- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) — The app is fully local: no network calls, no telemetry, no analytics, no CDN fetches.
+- Open [**Make no network connections at runtime**](practice-make-no-network-connections-at-runtime.md) — The app is local-first: no network calls except the startup version check and user-triggered remote PR/MR review; nothing is sent to the forge.
 ### #scope
 - Open [**Default bootstrap scope**](../knowledge-base/bootstrap/discovery/map-default-bootstrap-scope.md) — With no path argument, kb-bootstrap scans \`docs/\`, top-level README, CONTRIBUTING, ARCHITECTURE, and root-level \`*.md\` files.
 - Open [**Stick to markdown documentation; do not read code files during bootstrap**](../knowledge-base/bootstrap/discovery/practice-stick-to-markdown-documentation-do-not-read-code-files-during-bootstrap.md) — Bootstrap extracts what's already been written down — read only markdown docs, not source code.

--- a/.ai/kenkeep/nodes/review-xml/schema/index.md
+++ b/.ai/kenkeep/nodes/review-xml/schema/index.md
@@ -20,7 +20,7 @@ _None._
 - Open [**XSD schema location**](map-xsd-schema-location.md) to learn about: The canonical v3 XSD is under the apply skill and must remain byte-identical to the serializer's embedded XSD; the OpenCode path is a symlink. #self-review #xsd #schema
 - Open [**self-review XML schema (self-review-v3.xsd)**](map-self-review-xml-schema-self-review-v1-xsd.md) to learn about: The v3 XSD beside self-review-apply defines review metadata, files, comments, suggestions, attachments, and ordered replies. #self-review #xsd #schema
 - Open [**self-review XML v3 schema**](map-self-review-xml-v1-schema.md) to learn about: The canonical v3 XSD defines files, comments, suggestions, attachments, and ordered reply threads. #self-review #xml #schema
-- Open [**self-review-v3 XSD output format**](map-self-review-v1-xsd-output-format.md) to learn about: Review output uses self-review-v3.xsd and urn:self-review:v3; v1 and v2 schemas remain frozen for older consumers. #xml #schema #output
+- Open [**self-review-v3 XSD output format**](map-self-review-v1-xsd-output-format.md) to learn about: Review output uses self-review-v3.xsd and urn:self-review:v3; v1 and v2 stay frozen, while the current version may gain optional attributes additively. #xml #schema #output
 
 ## By topic
 
@@ -42,7 +42,7 @@ _None._
 - Open [**Keep the v3 XSD schema in sync across its two locations**](practice-keep-the-xsd-schema-in-sync-across-its-two-locations.md) — Keep the canonical v3 XSD and the serializer's embedded XSD byte-identical, and preserve the OpenCode skill symlinks.
 ### #output
 - Open [**Design XML output to be parsed by LLMs**](practice-design-xml-output-to-be-parsed-by-llms.md) — Review output is structured XML with an XSD schema so LLMs can reliably parse and act on feedback.
-- Open [**self-review-v3 XSD output format**](map-self-review-v1-xsd-output-format.md) — Review output uses self-review-v3.xsd and urn:self-review:v3; v1 and v2 schemas remain frozen for older consumers.
+- Open [**self-review-v3 XSD output format**](map-self-review-v1-xsd-output-format.md) — Review output uses self-review-v3.xsd and urn:self-review:v3; v1 and v2 stay frozen, while the current version may gain optional attributes additively.
 - Open [**Treat self-review as a CLI-first, one-shot tool**](../../app/cli/practice-treat-self-review-as-a-cli-first-one-shot-tool.md) — self-review launches from the terminal, writes review output to a file, then exits. No servers or persistent state.
 ### #ai
 - Open [**Design XML output to be parsed by LLMs**](practice-design-xml-output-to-be-parsed-by-llms.md) — Review output is structured XML with an XSD schema so LLMs can reliably parse and act on feedback.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,8 +123,13 @@ export { createGitLabProvider } from './gitlab-provider';
 
 // Clone-aware diff materializer (remote PR/MR git plane)
 export {
+  detectExistingClone,
   materialize,
   resolveRemoteDefaultBranch,
   defaultGitRunner,
 } from './materializer';
-export type { MaterializeMode, MaterializeResult } from './materializer';
+export type {
+  ExistingClone,
+  MaterializeMode,
+  MaterializeResult,
+} from './materializer';

--- a/packages/core/src/materializer.test.ts
+++ b/packages/core/src/materializer.test.ts
@@ -7,7 +7,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { ForgeCommandResult, ForgeCommandRunner, ForgeUrl } from './forge-provider';
-import { materialize, resolveRemoteDefaultBranch } from './materializer';
+import {
+  detectExistingClone,
+  materialize,
+  resolveRemoteDefaultBranch,
+} from './materializer';
 
 const BASE_SHA = 'a'.repeat(40);
 const HEAD_SHA = 'b'.repeat(40);
@@ -343,6 +347,35 @@ describe('materialize', () => {
 });
 
 describe('resolveRemoteDefaultBranch', () => {
+  it('reuses a detected clone so SSH transport is preserved', async () => {
+    const handlers = existingCloneHandlers(
+      'origin\tgit@github.com:e0ipso/self-review.git (fetch)\n'
+    );
+    handlers['ls-remote'] = ok(
+      'ref: refs/heads/main\tHEAD\n' + `${HEAD_SHA}\tHEAD\n`
+    );
+    const { runner, calls } = createRunner(handlers);
+
+    const existing = await detectExistingClone(
+      githubUrl,
+      '/home/user/project/sub',
+      runner
+    );
+    const branch = await resolveRemoteDefaultBranch(githubUrl, runner, existing);
+
+    expect(branch).toBe('main');
+    const call = findCall(calls, 'ls-remote');
+    expect(call).toEqual([
+      'git',
+      '-C',
+      '/home/user/project',
+      'ls-remote',
+      '--symref',
+      'origin',
+      'HEAD',
+    ]);
+  });
+
   it('resolves the remote HEAD symref via git ls-remote', async () => {
     const { runner, calls } = createRunner({
       'ls-remote': ok('ref: refs/heads/main\tHEAD\n' + `${HEAD_SHA}\tHEAD\n`),
@@ -366,6 +399,21 @@ describe('resolveRemoteDefaultBranch', () => {
     );
     await expect(resolveRemoteDefaultBranch(githubUrl, runner)).rejects.toThrow(
       /gh auth setup-git/
+    );
+  });
+
+  it('identifies the repository when a matching remote lookup fails', async () => {
+    const { runner } = createRunner({
+      'ls-remote': fail('fatal: unable to access repository'),
+    });
+
+    await expect(
+      resolveRemoteDefaultBranch(githubUrl, runner, {
+        repoPath: '/home/user/project',
+        remoteName: 'origin',
+      })
+    ).rejects.toThrow(
+      'ls-remote of origin (https://github.com/e0ipso/self-review.git)'
     );
   });
 

--- a/packages/core/src/materializer.ts
+++ b/packages/core/src/materializer.ts
@@ -40,6 +40,12 @@ export interface MaterializeResult {
   cleanup: () => void;
 }
 
+/** A local clone whose fetch remote matches the requested forge repository. */
+export interface ExistingClone {
+  repoPath: string;
+  remoteName: string;
+}
+
 /** Local namespaced refs the materializer fetches into (never branches). */
 const LOCAL_BASE_REF = 'refs/self-review/base';
 const LOCAL_HEAD_REF = 'refs/self-review/head';
@@ -174,11 +180,11 @@ async function revParse(
  * Detect an existing clone: when `cwd` is inside a git repository with a
  * remote matching the forge URL, return `{ repoPath, remoteName }`.
  */
-async function detectExistingClone(
-  runner: ForgeCommandRunner,
+export async function detectExistingClone(
+  url: ForgeUrl,
   cwd: string,
-  url: ForgeUrl
-): Promise<{ repoPath: string; remoteName: string } | null> {
+  runner: ForgeCommandRunner = defaultGitRunner
+): Promise<ExistingClone | null> {
   const toplevel = await runner('git', ['-C', cwd, 'rev-parse', '--show-toplevel']);
   if (toplevel.exitCode !== 0) {
     return null;
@@ -284,7 +290,8 @@ async function materializeIntoTempClone(
  * branch and PR/MR head refs are fetched into that clone under
  * `refs/self-review/*` — read-only for the working tree. Otherwise a
  * blobless clone is created in a unique directory under the OS temp root
- * and `cleanup()` removes exactly that directory.
+ * and `cleanup()` removes exactly that directory. Callers that already
+ * detected a clone may pass it to avoid repeating the git probes.
  *
  * The returned `headSha` is the live remote head, so callers can compare it
  * against a recorded `remote-head-sha` for drift detection.
@@ -293,9 +300,13 @@ export async function materialize(
   url: ForgeUrl,
   baseBranch: string,
   cwd: string,
-  runner: ForgeCommandRunner = defaultGitRunner
+  runner: ForgeCommandRunner = defaultGitRunner,
+  existingClone?: ExistingClone | null
 ): Promise<MaterializeResult> {
-  const existing = await detectExistingClone(runner, cwd, url);
+  const existing =
+    existingClone === undefined
+      ? await detectExistingClone(url, cwd, runner)
+      : existingClone;
   if (existing) {
     return materializeIntoExistingClone(
       runner,
@@ -311,21 +322,32 @@ export async function materialize(
 /**
  * Git-only fallback for the base branch when no forge CLI is available:
  * resolves the remote's default branch from its HEAD symref via
- * `git ls-remote --symref <url> HEAD`. No forge API involved.
+ * `git ls-remote --symref <remote> HEAD`. When an existing matching clone
+ * is supplied, the configured remote is used so its SSH/HTTPS transport
+ * and credentials are preserved. Otherwise the forge HTTPS URL is used.
+ * No forge API involved.
  */
 export async function resolveRemoteDefaultBranch(
   url: ForgeUrl,
-  runner: ForgeCommandRunner = defaultGitRunner
+  runner: ForgeCommandRunner = defaultGitRunner,
+  existing: ExistingClone | null = null
 ): Promise<string> {
   const cloneUrl = cloneUrlFor(url);
-  const result = await runner('git', ['ls-remote', '--symref', cloneUrl, 'HEAD']);
+  const remote = existing?.remoteName ?? cloneUrl;
+  // Errors must identify the repository; a bare alias such as "origin"
+  // does not say which repository the lookup was made against.
+  const label = existing ? `${remote} (${cloneUrl})` : cloneUrl;
+  const args = existing
+    ? ['-C', existing.repoPath, 'ls-remote', '--symref', remote, 'HEAD']
+    : ['ls-remote', '--symref', remote, 'HEAD'];
+  const result = await runner('git', args);
   if (result.exitCode !== 0) {
-    throw gitFailure(`ls-remote of ${cloneUrl}`, result, true);
+    throw gitFailure(`ls-remote of ${label}`, result, true);
   }
   const match = /^ref:\s+refs\/heads\/(\S+)\s+HEAD$/m.exec(result.stdout);
   if (!match) {
     throw new Error(
-      `Failed to resolve the default branch of ${cloneUrl}: ` +
+      `Failed to resolve the default branch of ${label}: ` +
         'git ls-remote returned no HEAD symref.'
     );
   }

--- a/src/main/fetch-comments.test.ts
+++ b/src/main/fetch-comments.test.ts
@@ -167,6 +167,7 @@ describe('runFetchComments', () => {
     deps = {
       runner: vi.fn(),
       createProvider: vi.fn().mockImplementation(() => provider),
+      detectExistingClone: vi.fn().mockResolvedValue(null),
       materialize: vi.fn().mockResolvedValue(materializeResult()),
       resolveRemoteDefaultBranch: vi.fn().mockResolvedValue('trunk'),
       loadDiffFiles: vi.fn().mockResolvedValue([makeDiffFile('src/a.ts')]),
@@ -202,6 +203,7 @@ describe('runFetchComments', () => {
     const materializeMock = deps.materialize as ReturnType<typeof vi.fn>;
     expect(materializeMock.mock.calls[0][1]).toBe('main');
     expect(materializeMock.mock.calls[0][2]).toBe('/work');
+    expect(materializeMock.mock.calls[0][4]).toBeUndefined();
   });
 
   it('falls back to the git-only default branch with a stderr notice when the CLI is unavailable', async () => {
@@ -211,9 +213,19 @@ describe('runFetchComments', () => {
 
     await runFetchComments(PR_URL, { cwd: '/work', deps });
 
-    expect(deps.resolveRemoteDefaultBranch).toHaveBeenCalled();
+    expect(deps.detectExistingClone).toHaveBeenCalledWith(
+      expect.anything(),
+      '/work',
+      deps.runner
+    );
+    expect(deps.resolveRemoteDefaultBranch).toHaveBeenCalledWith(
+      expect.anything(),
+      deps.runner,
+      null
+    );
     const materializeMock = deps.materialize as ReturnType<typeof vi.fn>;
     expect(materializeMock.mock.calls[0][1]).toBe('trunk');
+    expect(materializeMock.mock.calls[0][4]).toBeNull();
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('falling back')
     );

--- a/src/main/fetch-comments.ts
+++ b/src/main/fetch-comments.ts
@@ -21,10 +21,14 @@ import { createGitHubProvider } from '../../packages/core/src/github-provider';
 import { createGitLabProvider } from '../../packages/core/src/gitlab-provider';
 import {
   defaultGitRunner,
+  detectExistingClone,
   materialize,
   resolveRemoteDefaultBranch,
 } from '../../packages/core/src/materializer';
-import type { MaterializeResult } from '../../packages/core/src/materializer';
+import type {
+  ExistingClone,
+  MaterializeResult,
+} from '../../packages/core/src/materializer';
 import {
   mapThreadsToReviewComments,
   REVIEW_LEVEL_FILE_PATH,
@@ -54,11 +58,18 @@ export interface FetchCommentsDeps {
     url: ForgeUrl,
     baseBranch: string,
     cwd: string,
-    runner: ForgeCommandRunner
+    runner: ForgeCommandRunner,
+    existingClone?: ExistingClone | null
   ) => Promise<MaterializeResult>;
+  detectExistingClone: (
+    url: ForgeUrl,
+    cwd: string,
+    runner: ForgeCommandRunner
+  ) => Promise<ExistingClone | null>;
   resolveRemoteDefaultBranch: (
     url: ForgeUrl,
-    runner: ForgeCommandRunner
+    runner: ForgeCommandRunner,
+    existing?: ExistingClone | null
   ) => Promise<string>;
   loadDiffFiles: (
     repoPath: string,
@@ -78,10 +89,9 @@ function defaultDeps(): FetchCommentsDeps {
       forge === 'github'
         ? createGitHubProvider(runner)
         : createGitLabProvider(runner),
-    materialize: (url, baseBranch, cwd, runner) =>
-      materialize(url, baseBranch, cwd, runner),
-    resolveRemoteDefaultBranch: (url, runner) =>
-      resolveRemoteDefaultBranch(url, runner),
+    detectExistingClone,
+    materialize,
+    resolveRemoteDefaultBranch,
     loadDiffFiles: async (repoPath, baseSha, headSha) =>
       // Triple-dot: diff from the merge base, matching how forges present a
       // PR/MR diff. Runs inside the materialized clone.
@@ -214,6 +224,7 @@ export async function runFetchComments(
   const provider = deps.createProvider(forgeUrl.forge, deps.runner);
 
   let baseBranch: string;
+  let existingClone: ExistingClone | null | undefined;
   try {
     baseBranch = await provider.fetchBaseBranch(forgeUrl);
   } catch (error) {
@@ -223,7 +234,16 @@ export async function runFetchComments(
       `[fetch-comments] ${error.cli} unavailable for the base-branch lookup — ` +
         'falling back to the remote default branch via git ls-remote.'
     );
-    baseBranch = await deps.resolveRemoteDefaultBranch(forgeUrl, deps.runner);
+    existingClone = await deps.detectExistingClone(
+      forgeUrl,
+      cwd,
+      deps.runner
+    );
+    baseBranch = await deps.resolveRemoteDefaultBranch(
+      forgeUrl,
+      deps.runner,
+      existingClone
+    );
   }
   console.error(`[fetch-comments] Base branch: ${baseBranch}`);
 
@@ -231,7 +251,8 @@ export async function runFetchComments(
     forgeUrl,
     baseBranch,
     cwd,
-    deps.runner
+    deps.runner,
+    existingClone
   );
   try {
     let threads;

--- a/src/main/remote-mode.test.ts
+++ b/src/main/remote-mode.test.ts
@@ -61,6 +61,7 @@ function makeDeps(overrides: Partial<RemoteSessionDeps> = {}): RemoteSessionDeps
   };
   return {
     createProvider: vi.fn(() => provider),
+    detectExistingClone: vi.fn(async () => null),
     materialize: vi.fn(async () => makeMaterializeResult()),
     resolveRemoteDefaultBranch: vi.fn(async () => 'trunk'),
     runner: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
@@ -116,7 +117,8 @@ describe('startRemoteSession', () => {
       expect.objectContaining({ forge: 'github', owner: 'octo', repo: 'repo', number: 42 }),
       'main',
       '/cwd',
-      deps.runner
+      deps.runner,
+      undefined
     );
     expect(session.repoPath).toBe('/tmp/self-review-clone');
     expect(session.gitDiffArgs).toEqual(['aaa111...bbb222']);
@@ -156,12 +158,22 @@ describe('startRemoteSession', () => {
     const deps = makeDeps({ createProvider: vi.fn(() => provider) });
     const session = await startRemoteSession(PR_URL, '/cwd', deps);
 
-    expect(deps.resolveRemoteDefaultBranch).toHaveBeenCalled();
+    expect(deps.detectExistingClone).toHaveBeenCalledWith(
+      expect.anything(),
+      '/cwd',
+      deps.runner
+    );
+    expect(deps.resolveRemoteDefaultBranch).toHaveBeenCalledWith(
+      expect.anything(),
+      deps.runner,
+      null
+    );
     expect(deps.materialize).toHaveBeenCalledWith(
       expect.anything(),
       'trunk',
       '/cwd',
-      deps.runner
+      deps.runner,
+      null
     );
     // Thread fetch is skipped entirely — the CLI is known unavailable.
     expect(provider.fetchThreads).not.toHaveBeenCalled();

--- a/src/main/remote-mode.ts
+++ b/src/main/remote-mode.ts
@@ -16,6 +16,7 @@ import {
   ForgeCliUnavailableError,
   createGitHubProvider,
   createGitLabProvider,
+  detectExistingClone,
   materialize,
   resolveRemoteDefaultBranch,
   defaultGitRunner,
@@ -27,6 +28,7 @@ import type {
   ForgeName,
   ForgeProvider,
   ForgeUrl,
+  ExistingClone,
   MaterializeMode,
   MaterializeResult,
 } from '../../packages/core/src/index';
@@ -67,11 +69,18 @@ export interface RemoteSessionDeps {
     url: ForgeUrl,
     baseBranch: string,
     cwd: string,
-    runner: ForgeCommandRunner
+    runner: ForgeCommandRunner,
+    existingClone?: ExistingClone | null
   ) => Promise<MaterializeResult>;
+  detectExistingClone: (
+    url: ForgeUrl,
+    cwd: string,
+    runner: ForgeCommandRunner
+  ) => Promise<ExistingClone | null>;
   resolveRemoteDefaultBranch: (
     url: ForgeUrl,
-    runner: ForgeCommandRunner
+    runner: ForgeCommandRunner,
+    existing?: ExistingClone | null
   ) => Promise<string>;
   runner: ForgeCommandRunner;
   /** Loads the diff from the clone. Untracked files are never included. */
@@ -92,6 +101,7 @@ function defaultCreateProvider(
 
 const defaultDeps: RemoteSessionDeps = {
   createProvider: defaultCreateProvider,
+  detectExistingClone,
   materialize,
   resolveRemoteDefaultBranch,
   runner: defaultGitRunner,
@@ -129,6 +139,7 @@ export async function startRemoteSession(
 
   let cliAvailable = true;
   let baseBranch: string;
+  let existingClone: ExistingClone | null | undefined;
   try {
     baseBranch = await provider.fetchBaseBranch(forgeUrl);
   } catch (error) {
@@ -140,10 +151,21 @@ export async function startRemoteSession(
       `[remote] Forge CLI unavailable (${error.cli}): ${error.message} — ` +
         'falling back to the remote default branch via git.'
     );
-    baseBranch = await d.resolveRemoteDefaultBranch(forgeUrl, d.runner);
+    existingClone = await d.detectExistingClone(forgeUrl, cwd, d.runner);
+    baseBranch = await d.resolveRemoteDefaultBranch(
+      forgeUrl,
+      d.runner,
+      existingClone
+    );
   }
 
-  const materialized = await d.materialize(forgeUrl, baseBranch, cwd, d.runner);
+  const materialized = await d.materialize(
+    forgeUrl,
+    baseBranch,
+    cwd,
+    d.runner,
+    existingClone
+  );
 
   let fetchedComments: ReviewComment[] = [];
   let threadSyncAvailable = false;


### PR DESCRIPTION
## Summary

- honor an existing clone's configured remote transport during forge-CLI fallback
- reuse clone detection across default-branch lookup and materialization
- improve failure context and extend orchestration coverage
- refresh the current Kenkeep indexes

## Validation

- npm run lint (passes with three pre-existing warnings)
- npm run test:unit (685 tests passed)
- TypeScript no-emit checks

Fixes #130