### PR TITLE
fix: hide the output path change button when it cannot work

### DIFF
--- a/packages/react/src/components/FileTree.test.tsx
+++ b/packages/react/src/components/FileTree.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import type { DiffFile } from '@self-review/types';
+import type { DiffFile, OutputPathInfo } from '@self-review/types';
 
 import { installBrowserApiStubs } from '../test-helpers';
 
@@ -11,6 +11,8 @@ import FileTree from './FileTree';
 import { ConfigProvider, useConfig } from '../context/ConfigContext';
 import { ReviewProvider } from '../context/ReviewContext';
 import { DiffNavigationProvider } from '../context/DiffNavigationContext';
+import { ReviewAdapterProvider } from '../context/ReviewAdapterContext';
+import type { ReviewAdapter } from '../adapter';
 
 const file: DiffFile = {
   oldPath: 'src/foo.ts',
@@ -56,5 +58,42 @@ describe('FileTree view-mode toggle', () => {
     expect(screen.getByTestId('probe-diff-view').textContent).toBe('split');
     fireEvent.click(screen.getByTestId('view-mode-unified'));
     expect(screen.getByTestId('probe-diff-view').textContent).toBe('unified');
+  });
+});
+
+const outputPath: OutputPathInfo = {
+  resolvedOutputPath: '/repo/review.xml',
+  outputPathWritable: true,
+};
+
+const loadDiff: ReviewAdapter['loadDiff'] = async () => ({
+  files: [file],
+  source: { type: 'directory', sourcePath: '/repo' },
+});
+
+function renderWithAdapter(adapter: ReviewAdapter) {
+  return render(
+    <ReviewAdapterProvider adapter={adapter}>
+      <ConfigProvider initialOutputPath={outputPath}>
+        <ReviewProvider initialFiles={[file]}>
+          <DiffNavigationProvider>
+            <FileTree />
+          </DiffNavigationProvider>
+        </ReviewProvider>
+      </ConfigProvider>
+    </ReviewAdapterProvider>
+  );
+}
+
+describe('FileTree output path footer', () => {
+  it('hides the change button for an adapter without changeOutputPath', () => {
+    renderWithAdapter({ loadDiff });
+    expect(screen.getByText('Output:')).not.toBeNull();
+    expect(screen.queryByText('Change...')).toBeNull();
+  });
+
+  it('shows the change button when the adapter implements changeOutputPath', () => {
+    renderWithAdapter({ loadDiff, changeOutputPath: async () => null });
+    expect(screen.queryByText('Change...')).not.toBeNull();
   });
 });

--- a/packages/react/src/components/FileTree.tsx
+++ b/packages/react/src/components/FileTree.tsx
@@ -303,14 +303,17 @@ export default function FileTree() {
               ) : (
                 <AlertCircle className='h-3.5 w-3.5 text-red-500 shrink-0' />
               )}
-              <Button
-                variant='ghost'
-                size='sm'
-                className='h-6 px-2 text-xs ml-auto'
-                onClick={handleChangeOutputPath}
-              >
-                Change...
-              </Button>
+              {/* Only offered when the host can actually change the path. */}
+              {adapter?.changeOutputPath && (
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  className='h-6 px-2 text-xs ml-auto'
+                  onClick={handleChangeOutputPath}
+                >
+                  Change...
+                </Button>
+              )}
             </div>
             {!outputPathInfo.outputPathWritable && (
               <p className='text-xs text-red-500'>Path not writable</p>

--- a/packages/react/src/components/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { useConfig } from '../context/ConfigContext';
 import { useReview } from '../context/ReviewContext';
 import { useGuide } from '../context/GuideContext';
+import { useAdapter } from '../context/ReviewAdapterContext';
 import { Button } from './ui/button';
 import { ToggleGroup, ToggleGroupItem } from './ui/toggle-group';
 import { Separator } from './ui/separator';
@@ -34,6 +35,7 @@ export default function Toolbar({ onFinishReview }: ToolbarProps = {}) {
   const { config, updateConfig, outputPathInfo } = useConfig();
   const { diffFiles, diffSource } = useReview();
   const { guide, mode: guideMode, setMode: setGuideMode } = useGuide();
+  const adapter = useAdapter();
   const [allCommentsCollapsed, setAllCommentsCollapsed] = useState(false);
 
   const stats = useMemo(() => {
@@ -324,7 +326,10 @@ export default function Toolbar({ onFinishReview }: ToolbarProps = {}) {
               </TooltipTrigger>
               {!outputPathInfo.outputPathWritable && (
                 <TooltipContent>
-                  Output path is not writable. Click &apos;Change...&apos; in the file tree to pick a save location.
+                  {/* The file tree only shows "Change..." when the host can change the path. */}
+                  {adapter?.changeOutputPath
+                    ? "Output path is not writable. Click 'Change...' in the file tree to pick a save location."
+                    : 'Output path is not writable.'}
                 </TooltipContent>
               )}
             </Tooltip>


### PR DESCRIPTION
I found this bug while working on creating an HTTP server adapter. While trying to keep my implementation simple, I created an adapter that does not support changing the output location at runtime.

The `FileTree` component renders the "Output:" footer with a "Change..." button whenever `outputPathInfo.resolvedOutputPath` is set. The existing click handler already bails out when the adapter has no `changeOutputPath`:

```ts
const handleChangeOutputPath = async () => {
if (!adapter?.changeOutputPath) return;
...
```

`changeOutputPath` is optional, so you can create a legitimate adapter that doesn't implement it. There just aren't any in the project right now.

So a host that embeds `@self-review/react` with a reduced adapter gets a button that looks legit, but it does nothing when clicked.

The fix renders the button only when the adapter implements the method.

## Testing

```
npm run test:unit
```

Two new cases in `FileTree.test.tsx` cover the footer: one adapter without `changeOutputPath` (no button, footer still
rendered) and one with it (button present).

To see it by hand, render `SingleFileReview` with an output path set. Before this change there is a "Change..." button that does nothing on click, after it there is no button.

Disclaimer; I used Claude Code while authoring this PR message and the code in this branch.