### PR TITLE
test: wait for the diff before finishing a directory review

### DIFF
--- a/tests/features/11-welcome-screen.feature
+++ b/tests/features/11-welcome-screen.feature
@@ -34,6 +34,7 @@ Feature: Welcome Screen and Directory Mode
       | file         | content             |
       | src/index.ts | console.log("hi");  |
     When I launch self-review with the directory path
+    And the file tree should list 1 file
     And I click "Finish Review"
     Then the output file should contain valid XML
     And the XML should contain a "source-path" attribute


### PR DESCRIPTION
Disclaimer; Authored with help from Claude Code.

This fixes a flakey test I came across while running tests (`npm run test:e2e:electron`) working on other things.

The scenario "Finish Review produces valid XML with source-path and no git-diff-args" goes straight from launching the app to clicking Finish Review:

```gherkin
When I launch self-review with the directory path
And I click "Finish Review"
```

`launchApp` resolves at `domcontentloaded` (`tests/steps/app.ts:138`). Nothing in there waits for the directory scan or the `diff:load` round trip. So when the click wins that race the renderer serializes a review state with no source and no files, and the assertion fails against an empty `<review>` element.

Other Finish Review scenarios already have an intervening assertion that happens to wait. The fix adds the same wait explicitly, using a step that already exists in `shared.steps.ts:152`.

## Reproducing the problem

It only shows up under full-suite load (e.g. `npm run test:e2e:electron`), which is why it feels random.

| How it was run | Result |
| --- | --- |
| Scenario alone, `--retries=0`, 8 runs | 8 passed |
| Its own feature file, `--retries=0`, 3 runs | 3 passed |
| Full `electron` project, 4 runs | failed 3 times |

With the wait added, the full project passed **6 of 6** runs with `--retries=0`.

The suite normally runs with `retries: 1`, which is probably why this usually surfaces as a "flaky" line rather than a failure.

## Testing instructions

```
npm run test:e2e:electron
```

To see the race before the fix, revert the one line and run the full project with `--retries=0` a few times:

```
npm run package && npx bddgen
xvfb-run --auto-servernum npx playwright test --project electron --retries=0
```