### PR TITLE
fix: prevent shell injection in git calls

### DIFF
--- a/packages/core/src/git.process.test.ts
+++ b/packages/core/src/git.process.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runGitDiff, runGitDiffAsync } from './git';
+
+// Exercise real child processes: mocked argv checks cannot detect shell expansion.
+describe.each(['sync', 'async'] as const)('literal git diff arguments (%s)', mode => {
+  const originalCwd = process.cwd();
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'self-review-test-diff-literal-'));
+    execFileSync('git', ['init', '-q', root]);
+    // The async wrapper receives an explicit cwd; the sync wrapper inherits it.
+    if (mode === 'sync') process.chdir(root);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    '$(touch${IFS}SELF_REVIEW_INJECTION_MARKER)',
+    '`touch${IFS}SELF_REVIEW_INJECTION_MARKER`',
+    'file with spaces.txt',
+    'file "with quotes".txt',
+    "file 'with quotes'.txt",
+  ])('reviews the literal filename without executing shell syntax: %s', async filename => {
+    writeFileSync(join(root, filename), 'selected content\n');
+    writeFileSync(join(root, 'other.txt'), 'unselected content\n');
+    execFileSync('git', ['add', '--', filename, 'other.txt'], { cwd: root });
+    const args = ['--cached', '--', filename];
+
+    const diff = mode === 'sync' ? runGitDiff(args) : await runGitDiffAsync(args, root);
+
+    expect(existsSync(join(root, 'SELF_REVIEW_INJECTION_MARKER'))).toBe(false);
+    expect(diff).toContain('+selected content');
+    expect(diff).not.toContain('+unselected content');
+  });
+});

--- a/packages/core/src/git.test.ts
+++ b/packages/core/src/git.test.ts
@@ -23,12 +23,13 @@ describe('git', () => {
 
   describe('runGitDiff', () => {
     it('executes git diff with provided arguments', () => {
-      vi.mocked(child_process.execSync).mockReturnValue('diff output');
+      vi.mocked(child_process.execFileSync).mockReturnValue('diff output');
 
       const result = runGitDiff(['--staged']);
 
-      expect(child_process.execSync).toHaveBeenCalledWith(
-        'git diff --staged',
+      expect(child_process.execFileSync).toHaveBeenCalledWith(
+        'git',
+        ['diff', '--staged'],
         expect.objectContaining({
           encoding: 'utf-8',
           maxBuffer: 50 * 1024 * 1024,
@@ -40,8 +41,7 @@ describe('git', () => {
     it('checks git availability before running diff', () => {
       vi.mocked(child_process.execSync)
         .mockImplementationOnce(() => '') // git --version
-        .mockImplementationOnce(() => '') // git rev-parse
-        .mockImplementationOnce(() => 'diff output'); // git diff
+        .mockImplementationOnce(() => ''); // git rev-parse
 
       runGitDiff(['--staged']);
 
@@ -55,8 +55,7 @@ describe('git', () => {
     it('checks repository before running diff', () => {
       vi.mocked(child_process.execSync)
         .mockImplementationOnce(() => '') // git --version
-        .mockImplementationOnce(() => '') // git rev-parse
-        .mockImplementationOnce(() => 'diff output'); // git diff
+        .mockImplementationOnce(() => ''); // git rev-parse
 
       runGitDiff(['--staged']);
 
@@ -96,12 +95,13 @@ describe('git', () => {
     });
 
     it('handles multiple git diff arguments', () => {
-      vi.mocked(child_process.execSync).mockReturnValue('diff output');
+      vi.mocked(child_process.execFileSync).mockReturnValue('diff output');
 
       runGitDiff(['--staged', '--ignore-space-change', '--', 'src/']);
 
-      expect(child_process.execSync).toHaveBeenCalledWith(
-        'git diff --staged --ignore-space-change -- src/',
+      expect(child_process.execFileSync).toHaveBeenCalledWith(
+        'git',
+        ['diff', '--staged', '--ignore-space-change', '--', 'src/'],
         expect.any(Object)
       );
     });
@@ -109,10 +109,10 @@ describe('git', () => {
     it('exits with error on git diff failure', () => {
       vi.mocked(child_process.execSync)
         .mockImplementationOnce(() => '') // git --version
-        .mockImplementationOnce(() => '') // git rev-parse
-        .mockImplementationOnce(() => {
-          throw new Error('invalid revision');
-        });
+        .mockImplementationOnce(() => ''); // git rev-parse
+      vi.mocked(child_process.execFileSync).mockImplementationOnce(() => {
+        throw new Error('invalid revision');
+      });
 
       runGitDiff(['invalid..revision']);
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -1,11 +1,12 @@
 // src/main/git.ts
 // Git command execution
 
-import { execSync, exec, execFile } from 'child_process';
+import { execSync, exec, execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import { generateSyntheticDiffs } from './synthetic-diff';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export function runGitDiff(args: string[]): string {
   try {
@@ -28,7 +29,7 @@ export function runGitDiff(args: string[]): string {
     }
 
     // Run git diff with the provided arguments
-    const result = execSync(`git diff ${args.join(' ')}`, {
+    const result = execFileSync('git', ['diff', ...args], {
       encoding: 'utf-8',
       maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large diffs
     });
@@ -108,7 +109,7 @@ export async function getRepoRootAsync(cwd?: string): Promise<string> {
  */
 export async function runGitDiffAsync(args: string[], cwd?: string): Promise<string> {
   try {
-    const { stdout } = await execAsync(`git diff ${args.join(' ')}`, {
+    const { stdout } = await execFileAsync('git', ['diff', ...args], {
       maxBuffer: 50 * 1024 * 1024, // 50MB buffer
       timeout: 30000, // 30 second timeout
       cwd,

--- a/src/main/startup-mode.test.ts
+++ b/src/main/startup-mode.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { determineMode } from './startup-mode';
+import { loadConfig } from './config';
+import { normalizeGitDiffArgs } from './cli';
 
 // determineMode reads the process CWD, so each suite runs from a temp tree.
 // The vitest main config runs in a forked process, where chdir is allowed.
@@ -86,6 +88,52 @@ describe('determineMode', () => {
     it('stays in git mode for a directory argument', () => {
       fs.mkdirSync(path.join(root, 'sub'));
       expect(determineMode(['sub'])).toBe('git');
+    });
+  });
+
+  describe('literal filenames', () => {
+    let root: string;
+    const marker = 'SELF_REVIEW_INJECTION_MARKER';
+
+    beforeEach(() => {
+      root = makeTempDir('self-review-mode-literal-');
+      execFileSync('git', ['init', '-q', root]);
+      process.chdir(root);
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it.each([
+      '$(touch${IFS}SELF_REVIEW_INJECTION_MARKER)',
+      '`touch${IFS}SELF_REVIEW_INJECTION_MARKER`',
+      'file with spaces.txt',
+      'file "with quotes".txt',
+      "file 'with quotes'.txt",
+    ])('detects tracked and untracked files literally: %s', filename => {
+      fs.writeFileSync(filename, 'content\n');
+      expect(determineMode(['--', filename])).toBe('file');
+      expect(fs.existsSync(marker)).toBe(false);
+
+      execFileSync('git', ['add', '--', filename]);
+      expect(determineMode(['--', filename])).toBe('git');
+      expect(fs.existsSync(marker)).toBe(false);
+    });
+
+    it.each([
+      '$(touch${IFS}SELF_REVIEW_INJECTION_MARKER)',
+      '`touch${IFS}SELF_REVIEW_INJECTION_MARKER`',
+    ])('does not execute filenames selected by configuration: %s', filename => {
+      fs.writeFileSync(filename, 'content\n');
+      fs.writeFileSync('.self-review.yaml', `default-diff-args: '${filename}'\n`);
+      const args = normalizeGitDiffArgs(
+        loadConfig().defaultDiffArgs.split(' ').filter(Boolean)
+      );
+
+      expect(determineMode(args)).toBe('file');
+      expect(fs.existsSync(marker)).toBe(false);
     });
   });
 });

--- a/src/main/startup-mode.ts
+++ b/src/main/startup-mode.ts
@@ -2,7 +2,7 @@
 // Startup mode detection: what the app should review, from the CLI args and the CWD.
 
 import { existsSync, statSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { resolve } from 'path';
 
 /**
@@ -22,7 +22,7 @@ function isInGitRepo(): boolean {
  */
 function isGitTracked(filePath: string): boolean {
   try {
-    execSync(`git ls-files --error-unmatch ${JSON.stringify(filePath)}`, {
+    execFileSync('git', ['ls-files', '--error-unmatch', '--', filePath], {
       stdio: 'ignore',
     });
     return true;


### PR DESCRIPTION
Repository-controlled filenames and diff arguments could execute shell commands during startup or diff loading. Pass them to Git as literal argv entries using `execFileSync` and promisified `execFile`, preserving cwd, timeouts, buffer limits, and error handling.

Adds real-process regression tests in temporary repositories for command substitution, backticks, spaces, and quotes, including filenames selected through `default-diff-args`. The tests reproduced the vulnerability before the fix.

Validation: all 747 unit tests pass; `npx tsc --noEmit` passes; lint passes with three existing warnings. E2E tests were not run in the dev container.

Fixes #145.
