### PR TITLE
fix(ci): install chromium for the serve tests, and reformat package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
       # that stops being true.
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends xauth libgtk-3-0 xvfb
       - run: npm ci
+      # The Electron tests launch the Electron binary from node_modules and so
+      # need no downloaded browser, but the serve step below drives a real
+      # Chromium and does.
+      - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e:electron
       # The step above packaged the app, so the serve/desktop comparison can
       # run for real here. SELF_REVIEW_REQUIRE_DESKTOP turns its skip into a

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "developer-tools"
   ],
   "author": {
-    "name": "Mateu Aguil\u00f3 Bosch",
+    "name": "Mateu Aguiló Bosch",
     "email": "mateu@mateuaguilo.com"
   },
   "license": "MIT",


### PR DESCRIPTION
`main` is currently failing tests for two different reasons.

## The serve tests have no browser (mine, from #158)

The serve step I added to the `electron-e2e` job needs Chromium, but that job never installs it. The Electron tests launch the binary straight from `node_modules`, so it had never needed a browser.

Example error:

```
Error: browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/...
```

I didn't catch this locally because I had Chromium cached from other testing.

Worth noting: this job is skipped on pull requests. I've tested it locally. But this run will be the first real test of it in CI. If desired, we could wire this up to allow for a manual run via `workflow_dispatch` but it's not set up currently.

## `package.json` isn't Prettier-formatted (from #148)

`format:check` fails on package.json:

```diff
-    "name": "Mateu Aguiló Bosch",
+    "name": "Mateu Aguil\u00f3 Bosch",
```

`prettier --write` fixes this.


## Things I tested locally

- `lint`, `format:check` and all five `typecheck:*` scripts pass locally
- serve spec failure reproduced by removing my cached copy of the browser, and then passing after `playwright install chromium`